### PR TITLE
Browser version ranges feature

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,12 @@
+from .ua_generator.data import browser_versions, browser_versions_idx_map
+
+#Preprocessing
+#Store the index of first appearance of a version in each browser_version list
+for k,v in browser_versions.items():
+    for idx,val in enumerate(v):
+        if(val.major not in browser_versions_idx_map[k]):
+            browser_versions_idx_map[k][val.major] = idx
+       
+
+
+

--- a/src/ua_generator/client_hints.py
+++ b/src/ua_generator/client_hints.py
@@ -6,7 +6,7 @@ License: Apache License 2.0
 from random import Random
 
 from . import serialization
-from .data import generator, platforms_mobile
+from .data import generator, PLATFORMS_MOBILE 
 from .data.version import AndroidVersion, WindowsVersion
 from .exceptions import InvalidArgumentError
 
@@ -30,7 +30,7 @@ class ClientHints:
         self.__cache = {}
 
     def get_mobile(self) -> bool:
-        return self.__generator.platform in platforms_mobile
+        return self.__generator.platform in PLATFORMS_MOBILE
 
     def get_platform(self) -> str:
         platform = self.__generator.platform

--- a/src/ua_generator/data/__init__.py
+++ b/src/ua_generator/data/__init__.py
@@ -3,17 +3,126 @@ Random User-Agent
 Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
+from .version import ChromiumVersion, Version
 
-devices = ('desktop', 'mobile')
-platforms = ('windows', 'macos', 'ios', 'linux', 'android')
-platforms_desktop = ('windows', 'macos', 'linux')  # Platforms on desktop devices
-platforms_mobile = ('ios', 'android')  # Platforms on mobile devices
-browsers = ('chrome', 'edge', 'firefox', 'safari')
-browsers_support_ch = ('chrome', 'edge')  # Browsers that support Client Hints
+DEVICES = ('desktop', 'mobile')
+PLATFORMS = ('windows', 'macos', 'ios', 'linux', 'android')
+PLATFORMS_DESKTOP = ('windows', 'macos', 'linux')  # Platforms on desktop devices
+PLATFORMS_MOBILE = ('ios', 'android')  # Platforms on mobile devices
+BROWSERS = ('chrome', 'edge', 'firefox', 'safari')
+BROWSERS_SUPPORT_CH = ('chrome', 'edge')  # Browsers that support Client Hints
+#empty index map initialized at import (preprocessing)
+browser_versions_idx_map = {"chrome":{}, 'edge':{},'safari':{},'firefox':{}}
+browser_versions = {
+    "chrome": [
+        ChromiumVersion(Version(major=100, minor=0, build=4896, patch=(0, 255))),
+        ChromiumVersion(Version(major=101, minor=0, build=4951, patch=(0, 255))),
+        ChromiumVersion(Version(major=102, minor=0, build=5005, patch=(0, 255))),
+        ChromiumVersion(Version(major=103, minor=0, build=5060, patch=(0, 255))),
+        ChromiumVersion(Version(major=104, minor=0, build=5112, patch=(0, 255))),
+        ChromiumVersion(Version(major=105, minor=0, build=5195, patch=(0, 255))),
+        ChromiumVersion(Version(major=106, minor=0, build=5249, patch=(0, 255))),
+        ChromiumVersion(Version(major=107, minor=0, build=5304, patch=(0, 255))),
+        ChromiumVersion(Version(major=108, minor=0, build=5359, patch=(0, 255))),
+        ChromiumVersion(Version(major=109, minor=0, build=5414, patch=(0, 255))),
+        ChromiumVersion(Version(major=110, minor=0, build=5481, patch=(0, 255))),
+        ChromiumVersion(Version(major=111, minor=0, build=5563, patch=(0, 255))),
+        ChromiumVersion(Version(major=112, minor=0, build=5615, patch=(0, 255))),
+        ChromiumVersion(Version(major=114, minor=0, build=5735, patch=(0, 255))),
+        ChromiumVersion(Version(major=115, minor=0, build=5790, patch=(0, 255))),
+        ChromiumVersion(Version(major=116, minor=0, build=5845, patch=(0, 255))),
+        ChromiumVersion(Version(major=117, minor=0, build=5938, patch=(0, 255))),
+        ChromiumVersion(Version(major=118, minor=0, build=5993, patch=(0, 255))),
+        ChromiumVersion(Version(major=119, minor=0, build=6045, patch=(0, 255))),
+        ChromiumVersion(Version(major=120, minor=0, build=6099, patch=(0, 255))),
+        ChromiumVersion(Version(major=121, minor=0, build=6167, patch=(0, 255))),
+        ChromiumVersion(Version(major=122, minor=0, build=6261, patch=(0, 255))),
+        ChromiumVersion(Version(major=123, minor=0, build=6312, patch=(0, 255))),
+        ChromiumVersion(Version(major=124, minor=0, build=6367, patch=(0, 255))),
+        ChromiumVersion(Version(major=125, minor=0, build=6422, patch=(0, 255))),
+        ChromiumVersion(Version(major=126, minor=0, build=6478, patch=(0, 255))),
+        ChromiumVersion(Version(major=127, minor=0, build=6533, patch=(0, 255))),
+    ],
 
-devices_s = { 'desktop', 'mobile' }
-platforms_s = { 'windows', 'macos', 'ios', 'linux', 'android' }
-platforms_desktop_s = { 'windows', 'macos', 'linux' }  # Platforms on desktop devices
-platforms_mobile_s = { 'ios', 'android' }  # Platforms on mobile devices
-browsers_s = { 'chrome', 'edge', 'firefox', 'safari' }
-browsers_support_ch_s = { 'chrome', 'edge' }  # Browsers that support Client Hints
+    "firefox": [
+        Version(major=103, minor=0, build=(0, 2)),
+        Version(major=104, minor=0, build=(0, 2)),
+        Version(major=105, minor=0, build=(0, 3)),
+        Version(major=106, minor=0, build=(0, 5)),
+        Version(major=107, minor=0, build=(0, 1)),
+        Version(major=108, minor=0, build=(0, 2)),
+        Version(major=109, minor=0, build=(0, 1)),
+        Version(major=110, minor=0, build=(0, 1)),
+        Version(major=111, minor=0, build=(0, 1)),
+        Version(major=112, minor=0, build=(0, 2)),
+        Version(major=113, minor=0, build=(0, 2)),
+        Version(major=114, minor=0, build=(0, 2)),
+        Version(major=115, minor=0, build=(0, 3)),
+        Version(major=115, minor=1, build=0),
+        Version(major=115, minor=2, build=(0, 1)),
+        Version(major=115, minor=3, build=(0, 1)),
+        Version(major=115, minor=4, build=0),
+        Version(major=115, minor=5, build=0),
+        Version(major=115, minor=6, build=0),
+        Version(major=115, minor=7, build=0),
+        Version(major=115, minor=8, build=0),
+        Version(major=116, minor=0, build=(0, 3)),
+        Version(major=117, minor=0, build=(0, 1)),
+        Version(major=118, minor=0, build=(0, 2)),
+        Version(major=119, minor=0, build=(0, 1)),
+        Version(major=120, minor=0, build=(0, 1)),
+        Version(major=121, minor=0, build=(0, 1)),
+        Version(major=122, minor=0, build=(0, 1)),
+        Version(major=123, minor=0, build=(0, 1)),
+        Version(major=124, minor=0, build=(0, 2)),
+        Version(major=125, minor=0, build=(1, 3)),
+        Version(major=126, minor=0, build=0),
+        Version(major=127, minor=0, build=(0, 2)),
+        Version(major=128, minor=0, build=(0, 3)),
+        Version(major=128, minor=1, build=0),
+        Version(major=129, minor=0, build=0),
+    ],
+
+    "edge": [
+        ChromiumVersion(Version(major=100, minor=0, build=1185, patch=(0, 99))),
+        ChromiumVersion(Version(major=101, minor=0, build=1210, patch=(0, 99))),
+        ChromiumVersion(Version(major=102, minor=0, build=1245, patch=(0, 99))),
+        ChromiumVersion(Version(major=103, minor=0, build=1264, patch=(0, 99))),
+        ChromiumVersion(Version(major=104, minor=0, build=1293, patch=(0, 99))),
+        ChromiumVersion(Version(major=105, minor=0, build=1343, patch=(0, 99))),
+        ChromiumVersion(Version(major=106, minor=0, build=1370, patch=(0, 99))),
+        ChromiumVersion(Version(major=107, minor=0, build=1418, patch=(0, 99))),
+        ChromiumVersion(Version(major=108, minor=0, build=1462, patch=(0, 99))),
+        ChromiumVersion(Version(major=109, minor=0, build=1518, patch=(0, 99))),
+        ChromiumVersion(Version(major=110, minor=0, build=1587, patch=(0, 99))),
+        ChromiumVersion(Version(major=111, minor=0, build=1661, patch=(0, 99))),
+        ChromiumVersion(Version(major=112, minor=0, build=1722, patch=(0, 99))),
+        ChromiumVersion(Version(major=113, minor=0, build=1774, patch=(0, 99))),
+        ChromiumVersion(Version(major=114, minor=0, build=1823, patch=(0, 99))),
+        ChromiumVersion(Version(major=115, minor=0, build=1901, patch=(0, 99))),
+        ChromiumVersion(Version(major=116, minor=0, build=1938, patch=(0, 99))),
+        ChromiumVersion(Version(major=117, minor=0, build=2045, patch=(0, 99))),
+        ChromiumVersion(Version(major=118, minor=0, build=2088, patch=(0, 99))),
+        ChromiumVersion(Version(major=119, minor=0, build=2151, patch=(0, 99))),
+        ChromiumVersion(Version(major=120, minor=0, build=2210, patch=(0, 99))),
+        ChromiumVersion(Version(major=121, minor=0, build=2277, patch=(0, 99))),
+        ChromiumVersion(Version(major=122, minor=0, build=2365, patch=(0, 99))),
+        ChromiumVersion(Version(major=123, minor=0, build=2420, patch=(0, 99))),
+        ChromiumVersion(Version(major=124, minor=0, build=2478, patch=(0, 99))),
+        ChromiumVersion(Version(major=125, minor=0, build=2535, patch=(0, 99))),
+        ChromiumVersion(Version(major=126, minor=0, build=2592, patch=(0, 99))),
+        ChromiumVersion(Version(major=127, minor=0, build=2651, patch=(0, 99))),
+        ChromiumVersion(Version(major=128, minor=0, build=2739, patch=(0, 99))),
+    ],
+
+    "safari": [
+        ChromiumVersion(Version(major=10, minor=0), webkit=Version(major=602, minor=4, build=8)),
+        ChromiumVersion(Version(major=11, minor=0), webkit=Version(major=604, minor=1, build=38)),
+        ChromiumVersion(Version(major=12, minor=(0, 1)), webkit=Version(major=605, minor=1, build=15)),
+        ChromiumVersion(Version(major=13, minor=(0, 1)), webkit=Version(major=605, minor=1, build=15)),
+        ChromiumVersion(Version(major=14, minor=(0, 1)), webkit=Version(major=605, minor=1, build=15)),
+        ChromiumVersion(Version(major=15, minor=(0, 6)), webkit=Version(major=605, minor=1, build=15)),
+        ChromiumVersion(Version(major=16, minor=(0, 6)), webkit=Version(major=605, minor=1, build=15)),
+        ChromiumVersion(Version(major=17, minor=(0, 6)), webkit=Version(major=605, minor=1, build=15)),
+    ]
+}

--- a/src/ua_generator/data/__init__.py
+++ b/src/ua_generator/data/__init__.py
@@ -5,10 +5,15 @@ License: Apache License 2.0
 """
 
 devices = ('desktop', 'mobile')
-
 platforms = ('windows', 'macos', 'ios', 'linux', 'android')
 platforms_desktop = ('windows', 'macos', 'linux')  # Platforms on desktop devices
 platforms_mobile = ('ios', 'android')  # Platforms on mobile devices
-
 browsers = ('chrome', 'edge', 'firefox', 'safari')
 browsers_support_ch = ('chrome', 'edge')  # Browsers that support Client Hints
+
+devices_s = { 'desktop', 'mobile' }
+platforms_s = { 'windows', 'macos', 'ios', 'linux', 'android' }
+platforms_desktop_s = { 'windows', 'macos', 'linux' }  # Platforms on desktop devices
+platforms_mobile_s = { 'ios', 'android' }  # Platforms on mobile devices
+browsers_s = { 'chrome', 'edge', 'firefox', 'safari' }
+browsers_support_ch_s = { 'chrome', 'edge' }  # Browsers that support Client Hints

--- a/src/ua_generator/data/browsers/chrome.py
+++ b/src/ua_generator/data/browsers/chrome.py
@@ -7,43 +7,19 @@ import random
 from typing import List
 
 from ..version import Version, ChromiumVersion
+from ...data import browser_versions,browser_versions_idx_map
 from ...options import Options
 
-# https://chromereleases.googleblog.com/search/label/Stable%20updates
-versions: List[ChromiumVersion] = [
-    ChromiumVersion(Version(major=100, minor=0, build=4896, patch=(0, 255))),
-    ChromiumVersion(Version(major=101, minor=0, build=4951, patch=(0, 255))),
-    ChromiumVersion(Version(major=102, minor=0, build=5005, patch=(0, 255))),
-    ChromiumVersion(Version(major=103, minor=0, build=5060, patch=(0, 255))),
-    ChromiumVersion(Version(major=104, minor=0, build=5112, patch=(0, 255))),
-    ChromiumVersion(Version(major=105, minor=0, build=5195, patch=(0, 255))),
-    ChromiumVersion(Version(major=106, minor=0, build=5249, patch=(0, 255))),
-    ChromiumVersion(Version(major=107, minor=0, build=5304, patch=(0, 255))),
-    ChromiumVersion(Version(major=108, minor=0, build=5359, patch=(0, 255))),
-    ChromiumVersion(Version(major=109, minor=0, build=5414, patch=(0, 255))),
-    ChromiumVersion(Version(major=110, minor=0, build=5481, patch=(0, 255))),
-    ChromiumVersion(Version(major=111, minor=0, build=5563, patch=(0, 255))),
-    ChromiumVersion(Version(major=112, minor=0, build=5615, patch=(0, 255))),
-    ChromiumVersion(Version(major=114, minor=0, build=5735, patch=(0, 255))),
-    ChromiumVersion(Version(major=115, minor=0, build=5790, patch=(0, 255))),
-    ChromiumVersion(Version(major=116, minor=0, build=5845, patch=(0, 255))),
-    ChromiumVersion(Version(major=117, minor=0, build=5938, patch=(0, 255))),
-    ChromiumVersion(Version(major=118, minor=0, build=5993, patch=(0, 255))),
-    ChromiumVersion(Version(major=119, minor=0, build=6045, patch=(0, 255))),
-    ChromiumVersion(Version(major=120, minor=0, build=6099, patch=(0, 255))),
-    ChromiumVersion(Version(major=121, minor=0, build=6167, patch=(0, 255))),
-    ChromiumVersion(Version(major=122, minor=0, build=6261, patch=(0, 255))),
-    ChromiumVersion(Version(major=123, minor=0, build=6312, patch=(0, 255))),
-    ChromiumVersion(Version(major=124, minor=0, build=6367, patch=(0, 255))),
-    ChromiumVersion(Version(major=125, minor=0, build=6422, patch=(0, 255))),
-    ChromiumVersion(Version(major=126, minor=0, build=6478, patch=(0, 255))),
-    ChromiumVersion(Version(major=127, minor=0, build=6533, patch=(0, 255))),
-]
 
 
 def get_version(options: Options) -> ChromiumVersion:
     weights = None
-    if options.weighted_versions:
+    min_ver_idx = browser_versions_idx_map['chrome'][options.browser_version_ranges['chrome'].min]
+    max_ver_idx = browser_versions_idx_map['chrome'][options.browser_version_ranges['chrome'].max]
+    versions = browser_versions['chrome'][min_ver_idx:max_ver_idx+1]
+
+    #Version ranges that range less than 3 versions currently unsupported with weighted_versions
+    if options.weighted_versions and len(versions) >= 3:
         weights = [1.0] * len(versions)
         weights[-1] = 10.0
         weights[-2] = 9.0

--- a/src/ua_generator/data/browsers/edge.py
+++ b/src/ua_generator/data/browsers/edge.py
@@ -6,46 +6,19 @@ License: Apache License 2.0
 import random
 from typing import List
 
+from ...data import browser_versions,browser_versions_idx_map
 from ..version import Version, ChromiumVersion
 from ...options import Options
 
-# https://docs.microsoft.com/en-us/deployedge/microsoft-edge-release-schedule
-versions: List[ChromiumVersion] = [
-    ChromiumVersion(Version(major=100, minor=0, build=1185, patch=(0, 99))),
-    ChromiumVersion(Version(major=101, minor=0, build=1210, patch=(0, 99))),
-    ChromiumVersion(Version(major=102, minor=0, build=1245, patch=(0, 99))),
-    ChromiumVersion(Version(major=103, minor=0, build=1264, patch=(0, 99))),
-    ChromiumVersion(Version(major=104, minor=0, build=1293, patch=(0, 99))),
-    ChromiumVersion(Version(major=105, minor=0, build=1343, patch=(0, 99))),
-    ChromiumVersion(Version(major=106, minor=0, build=1370, patch=(0, 99))),
-    ChromiumVersion(Version(major=107, minor=0, build=1418, patch=(0, 99))),
-    ChromiumVersion(Version(major=108, minor=0, build=1462, patch=(0, 99))),
-    ChromiumVersion(Version(major=109, minor=0, build=1518, patch=(0, 99))),
-    ChromiumVersion(Version(major=110, minor=0, build=1587, patch=(0, 99))),
-    ChromiumVersion(Version(major=111, minor=0, build=1661, patch=(0, 99))),
-    ChromiumVersion(Version(major=112, minor=0, build=1722, patch=(0, 99))),
-    ChromiumVersion(Version(major=113, minor=0, build=1774, patch=(0, 99))),
-    ChromiumVersion(Version(major=114, minor=0, build=1823, patch=(0, 99))),
-    ChromiumVersion(Version(major=115, minor=0, build=1901, patch=(0, 99))),
-    ChromiumVersion(Version(major=116, minor=0, build=1938, patch=(0, 99))),
-    ChromiumVersion(Version(major=117, minor=0, build=2045, patch=(0, 99))),
-    ChromiumVersion(Version(major=118, minor=0, build=2088, patch=(0, 99))),
-    ChromiumVersion(Version(major=119, minor=0, build=2151, patch=(0, 99))),
-    ChromiumVersion(Version(major=120, minor=0, build=2210, patch=(0, 99))),
-    ChromiumVersion(Version(major=121, minor=0, build=2277, patch=(0, 99))),
-    ChromiumVersion(Version(major=122, minor=0, build=2365, patch=(0, 99))),
-    ChromiumVersion(Version(major=123, minor=0, build=2420, patch=(0, 99))),
-    ChromiumVersion(Version(major=124, minor=0, build=2478, patch=(0, 99))),
-    ChromiumVersion(Version(major=125, minor=0, build=2535, patch=(0, 99))),
-    ChromiumVersion(Version(major=126, minor=0, build=2592, patch=(0, 99))),
-    ChromiumVersion(Version(major=127, minor=0, build=2651, patch=(0, 99))),
-    ChromiumVersion(Version(major=128, minor=0, build=2739, patch=(0, 99))),
-]
 
 
 def get_version(options: Options) -> ChromiumVersion:
-    weights = None
-    if options.weighted_versions:
+    weights = None 
+    min_ver_idx = browser_versions_idx_map['edge'][options.browser_version_ranges['edge'].min]
+    max_ver_idx = browser_versions_idx_map['edge'][options.browser_version_ranges['edge'].max]
+    versions = browser_versions['edge'][min_ver_idx:max_ver_idx+1]
+    #Version ranges that range less than 3 versions currently unsupported with weighted_versions
+    if options.weighted_versions and len(versions) >= 3:
         weights = [1.0] * len(versions)
         weights[-1] = 10.0
         weights[-2] = 9.0

--- a/src/ua_generator/data/browsers/firefox.py
+++ b/src/ua_generator/data/browsers/firefox.py
@@ -6,53 +6,16 @@ License: Apache License 2.0
 import random
 from typing import List
 
+from ...data import browser_versions,browser_versions_idx_map
 from ..version import Version
 from ...options import Options
-
-# https://www.mozilla.org/en-US/firefox/releases/
-versions: List[Version] = [
-    Version(major=103, minor=0, build=(0, 2)),
-    Version(major=104, minor=0, build=(0, 2)),
-    Version(major=105, minor=0, build=(0, 3)),
-    Version(major=106, minor=0, build=(0, 5)),
-    Version(major=107, minor=0, build=(0, 1)),
-    Version(major=108, minor=0, build=(0, 2)),
-    Version(major=109, minor=0, build=(0, 1)),
-    Version(major=110, minor=0, build=(0, 1)),
-    Version(major=111, minor=0, build=(0, 1)),
-    Version(major=112, minor=0, build=(0, 2)),
-    Version(major=113, minor=0, build=(0, 2)),
-    Version(major=114, minor=0, build=(0, 2)),
-    Version(major=115, minor=0, build=(0, 3)),
-    Version(major=115, minor=1, build=0),
-    Version(major=115, minor=2, build=(0, 1)),
-    Version(major=115, minor=3, build=(0, 1)),
-    Version(major=115, minor=4, build=0),
-    Version(major=115, minor=5, build=0),
-    Version(major=115, minor=6, build=0),
-    Version(major=115, minor=7, build=0),
-    Version(major=115, minor=8, build=0),
-    Version(major=116, minor=0, build=(0, 3)),
-    Version(major=117, minor=0, build=(0, 1)),
-    Version(major=118, minor=0, build=(0, 2)),
-    Version(major=119, minor=0, build=(0, 1)),
-    Version(major=120, minor=0, build=(0, 1)),
-    Version(major=121, minor=0, build=(0, 1)),
-    Version(major=122, minor=0, build=(0, 1)),
-    Version(major=123, minor=0, build=(0, 1)),
-    Version(major=124, minor=0, build=(0, 2)),
-    Version(major=125, minor=0, build=(1, 3)),
-    Version(major=126, minor=0, build=0),
-    Version(major=127, minor=0, build=(0, 2)),
-    Version(major=128, minor=0, build=(0, 3)),
-    Version(major=128, minor=1, build=0),
-    Version(major=129, minor=0, build=0),
-]
-
-
 def get_version(options: Options) -> Version:
     weights = None
-    if options.weighted_versions:
+    min_ver_idx = browser_versions_idx_map['firefox'][options.browser_version_ranges['firefox'].min]
+    max_ver_idx = browser_versions_idx_map['firefox'][options.browser_version_ranges['firefox'].max]
+    versions = browser_versions['firefox'][min_ver_idx:max_ver_idx+1]
+    #Version ranges that range less than 3 versions currently unsupported with weighted_versions
+    if options.weighted_versions and len(versions) >= 3:
         weights = [1.0] * len(versions)
         weights[-1] = 10.0
         weights[-2] = 9.0

--- a/src/ua_generator/data/browsers/safari.py
+++ b/src/ua_generator/data/browsers/safari.py
@@ -6,25 +6,18 @@ License: Apache License 2.0
 import random
 from typing import List
 
+from ...data import browser_versions,browser_versions_idx_map
 from ..version import Version, ChromiumVersion
 from ...options import Options
-
-# https://developer.apple.com/documentation/safari-release-notes
-versions: List[ChromiumVersion] = [
-    ChromiumVersion(Version(major=10, minor=0), webkit=Version(major=602, minor=4, build=8)),
-    ChromiumVersion(Version(major=11, minor=0), webkit=Version(major=604, minor=1, build=38)),
-    ChromiumVersion(Version(major=12, minor=(0, 1)), webkit=Version(major=605, minor=1, build=15)),
-    ChromiumVersion(Version(major=13, minor=(0, 1)), webkit=Version(major=605, minor=1, build=15)),
-    ChromiumVersion(Version(major=14, minor=(0, 1)), webkit=Version(major=605, minor=1, build=15)),
-    ChromiumVersion(Version(major=15, minor=(0, 6)), webkit=Version(major=605, minor=1, build=15)),
-    ChromiumVersion(Version(major=16, minor=(0, 6)), webkit=Version(major=605, minor=1, build=15)),
-    ChromiumVersion(Version(major=17, minor=(0, 6)), webkit=Version(major=605, minor=1, build=15)),
-]
 
 
 def get_version(options: Options) -> ChromiumVersion:
     weights = None
-    if options.weighted_versions:
+    min_ver_idx = browser_versions_idx_map['safari'][options.browser_version_ranges['safari'].min]
+    max_ver_idx = browser_versions_idx_map['safari'][options.browser_version_ranges['safari'].max]
+    versions = browser_versions['safari'][min_ver_idx:max_ver_idx+1]
+    #Version ranges that range less than 2 versions currently unsupported with weighted_versions
+    if options.weighted_versions and len(versions) >= 2:
         weights = [1.0] * len(versions)
         weights[-1] = 10.0
         weights[-2] = 9.0

--- a/src/ua_generator/data/version.py
+++ b/src/ua_generator/data/version.py
@@ -4,8 +4,7 @@ Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 import random
-from typing import Union
-
+from typing import List, Union
 
 class Version:
     major: int = None
@@ -23,7 +22,7 @@ class Version:
             # https://docs.python.org/3/tutorial/controlflow.html#tut-unpacking-arguments
             random.randrange(*x) if isinstance(x, tuple) else x,
             (major, minor, build, patch)
-        )
+        ) 
 
     def format(self, partitions=None, separator='.', trim_zero=False) -> str:
         versions = [self.major, self.minor, self.build, self.patch]
@@ -74,6 +73,12 @@ class WindowsVersion(Version):
         self.ch_platform = ch_platform
 
 
+class VersionRange:
+    def __init__(self, min_version, max_version):
+        self.min = min_version
+        self.max = max_version
+
+    
 version_types = (
     Version,
     ChromiumVersion,

--- a/src/ua_generator/headers.py
+++ b/src/ua_generator/headers.py
@@ -4,8 +4,8 @@ Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 from .client_hints import ClientHints
-from .data import browsers_support_ch
 from .data.generator import Generator
+from .data import BROWSERS_SUPPORT_CH
 
 
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-CH
@@ -24,7 +24,7 @@ class Headers:
         }
 
         # https://developer.mozilla.org/en-US/docs/Web/HTTP/Client_hints#low_entropy_hints
-        if self.__generator.browser in browsers_support_ch:
+        if self.__generator.browser in BROWSERS_SUPPORT_CH:
             self.add('sec-ch-ua')
             self.add('sec-ch-ua-mobile')
             self.add('sec-ch-ua-platform')
@@ -55,7 +55,7 @@ class Headers:
     def accept_ch(self, val: str):
         self.reset()
 
-        if self.__generator.browser not in browsers_support_ch:
+        if self.__generator.browser not in BROWSERS_SUPPORT_CH:
             return
 
         requested_hints = val.split(',')

--- a/src/ua_generator/options.py
+++ b/src/ua_generator/options.py
@@ -4,9 +4,26 @@ Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 
+from .data.version import VersionRange
+from .data import browser_versions 
+
 
 class Options:
-    weighted_versions = False
-
-    def __init__(self, weighted_versions: bool = False):
-        self.weighted_versions = weighted_versions
+    weighted_versions : bool = False
+    browser_version_ranges = {
+            'chrome': VersionRange(browser_versions['chrome'][0].major, browser_versions['chrome'][-1].major),
+            'edge': VersionRange(browser_versions['edge'][0].major, browser_versions['edge'][-1].major),
+            'safari': VersionRange(browser_versions['safari'][0].major, browser_versions['safari'][-1].major),
+            'firefox': VersionRange(browser_versions['firefox'][0].major, browser_versions['firefox'][-1].major)
+    }
+    def __init__(self,
+                weighted_versions=False, 
+                chrome_versions=(browser_versions['chrome'][0].major,browser_versions['chrome'][-1].major), 
+                firefox_versions=(browser_versions['firefox'][0].major, browser_versions['firefox'][-1].major), 
+                safari_versions=(browser_versions['safari'][0].major, browser_versions['safari'][-1].major), 
+                edge_versions=(browser_versions['edge'][0].major, browser_versions['edge'][-1].major)):
+        self.browser_version_ranges['chrome'] = VersionRange(chrome_versions[0],chrome_versions[1])
+        self.browser_version_ranges['edge'] = VersionRange(edge_versions[0],edge_versions[1])
+        self.browser_version_ranges['safari'] = VersionRange(safari_versions[0],safari_versions[1])
+        self.browser_version_ranges['firefox'] = VersionRange(firefox_versions[0],firefox_versions[1])
+        self.weighted_versions=weighted_versions 

--- a/src/ua_generator/user_agent.py
+++ b/src/ua_generator/user_agent.py
@@ -7,7 +7,7 @@ import typing
 
 from . import utils, exceptions
 from .client_hints import ClientHints
-from .data import devices, browsers, platforms, platforms_desktop, platforms_mobile
+from .data import devices_s, devices, browsers,browsers_s, platforms,platforms_s, platforms_desktop,platforms_desktop_s, platforms_mobile,platforms_mobile_s
 from .data.generator import Generator
 from .headers import Headers
 from .options import Options
@@ -27,14 +27,14 @@ class UserAgent:
         self.headers: Headers
 
     def __find_device(self) -> str:
-        if self.device is not None and self.device not in devices:
+        if self.device is not None and self.device not in devices_s:
             raise exceptions.InvalidArgumentError('No such device type found: {}'.format(self.device))
 
         # Override the device type, if the platform is specified
         if self.platform is not None:
-            if self.platform in platforms_desktop:
+            if self.platform in platforms_desktop_s:
                 self.device = 'desktop'
-            elif self.platform in platforms_mobile:
+            elif self.platform in platforms_mobile_s:
                 self.device = 'mobile'
 
         if self.device is None:
@@ -43,17 +43,17 @@ class UserAgent:
         return self.device
 
     def __find_platform(self) -> str:
-        if self.platform is not None and self.platform not in platforms:
+        if self.platform is not None and self.platform not in platforms_s:
             raise exceptions.InvalidArgumentError('No such platform found: {}'.format(self.platform))
 
         # Make the platform consistent with the device type and browser
-        if self.device == 'desktop' and self.platform not in platforms_desktop:
+        if self.device == 'desktop' and self.platform not in platforms_desktop_s:
             # Safari only supports the macOS and iOS platforms
-            if self.browser is not None and self.browser == 'safari':
+            if self.browser == 'safari':
                 self.platform = utils.choice(('macos', 'ios'))
             else:
                 self.platform = utils.choice(platforms_desktop)
-        elif self.device == 'mobile' and self.platform not in platforms_mobile:
+        elif self.device == 'mobile' and self.platform not in platforms_mobile_s:
             self.platform = utils.choice(platforms_mobile)
 
         if self.platform is None:
@@ -62,7 +62,7 @@ class UserAgent:
         return self.platform
 
     def __find_browser(self) -> str:
-        if self.browser is not None and self.browser not in browsers:
+        if self.browser is not None and self.browser not in browsers_s:
             raise exceptions.InvalidArgumentError('No such browser found: {}'.format(self.browser))
 
         if self.browser is None:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -6,9 +6,15 @@ License: Apache License 2.0
 import unittest
 
 import src.ua_generator as ua_generator
-
-
+from src.ua_generator.data import browser_versions_idx_map, browser_versions
+from src.ua_generator.options import Options
+from src.ua_generator.data.browsers import firefox,safari,chrome,edge
+from src.ua_generator import exceptions
 class TestBrowser(unittest.TestCase):
+    def assertWithinRange(self, value, min_value, max_value):
+        self.assertGreaterEqual(value, min_value, f"{value} is less than {min_value}")
+        self.assertLessEqual(value, max_value, f"{value} is greater than {max_value}")
+
     def test_browser(self):
         for i in range(0, 100):
             ua = ua_generator.generate(browser=('chrome',))
@@ -34,7 +40,43 @@ class TestBrowser(unittest.TestCase):
             ua = ua_generator.generate(platform=('macos', 'linux'), browser='safari')
             self.assertTrue((ua.platform == 'macos' and ua.browser == 'safari') or
                             (ua.platform == 'linux' and ua.browser == 'chrome'))
+    def test_idx_map(self):
+        #Ensure the idx_map is initialized correctly
+        for k,v in browser_versions_idx_map.items():
+            for k2,v2 in v.items():
+                self.assertTrue(browser_versions[k][v2].major == k2)
+    def test_valid_version_ranges(self):
+        #Ensure that a browser version range within the range specified is produced
+        chrome_options = Options(chrome_versions=(100, 105))
+        safari_options = Options(safari_versions=(10, 10))
+        edge_options = Options(edge_versions=(104, 105))
+        firefox_options = Options(firefox_versions=(103, 129))
 
+        # Assuming you have methods like get_version() that returns the major version number of the browser
+        chrome_version = chrome.get_version(chrome_options)
+        safari_version = safari.get_version(safari_options)
+        edge_version = edge.get_version(edge_options)
+        firefox_version = firefox.get_version(firefox_options)
 
+        self.assertWithinRange(
+        chrome_version.major, 
+        chrome_options.browser_version_ranges['chrome'].min, 
+        chrome_options.browser_version_ranges['chrome'].max
+        )   
+        self.assertWithinRange(
+            safari_version.major, 
+            safari_options.browser_version_ranges['safari'].min, 
+            safari_options.browser_version_ranges['safari'].max
+        )
+        self.assertWithinRange(
+            edge_version.major, 
+            edge_options.browser_version_ranges['edge'].min, 
+            edge_options.browser_version_ranges['edge'].max
+        )
+        self.assertWithinRange(
+            firefox_version.major, 
+            firefox_options.browser_version_ranges['firefox'].min, 
+            firefox_options.browser_version_ranges['firefox'].max
+        )
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_client_hints.py
+++ b/tests/test_client_hints.py
@@ -7,14 +7,14 @@ import unittest
 
 import src.ua_generator as ua_generator
 from src.ua_generator import serialization
-from src.ua_generator.data import browsers_support_ch
+from src.ua_generator.data import BROWSERS_SUPPORT_CH 
 from src.ua_generator.data.version import version_types
 
 
 class TestClientHints(unittest.TestCase):
     def test_ch_platform(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch, platform='macos')
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH, platform='macos')
             self.assertIsNotNone(ua.ch)
             self.assertTrue(type(ua.ch.platform) is str)
             self.assertEqual(ua.ch.platform, '"macOS"')
@@ -22,7 +22,7 @@ class TestClientHints(unittest.TestCase):
 
     def test_ch_platform_2(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch, platform='linux')
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH, platform='linux')
             self.assertIsNotNone(ua.ch)
             self.assertTrue(type(ua.ch.platform) is str)
             self.assertEqual(ua.ch.platform, '"Linux"')
@@ -30,7 +30,7 @@ class TestClientHints(unittest.TestCase):
 
     def test_ch_platform_version(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch)
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH)
             self.assertIsNotNone(ua.ch)
             self.assertTrue(type(ua.ch.platform_version) is str)
             self.assertEqual(ua.ch.platform_version, serialization.ch_string(ua.ch.get_platform_version()))
@@ -44,7 +44,7 @@ class TestClientHints(unittest.TestCase):
 
     def test_ch_mobile(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch, platform='android')
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH, platform='android')
             self.assertIsNotNone(ua.ch)
             self.assertTrue(type(ua.ch.mobile) is str)
             self.assertEqual(ua.ch.mobile, '?1')
@@ -55,7 +55,7 @@ class TestClientHints(unittest.TestCase):
 
     def test_ch_non_mobile(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch, platform='windows')
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH, platform='windows')
             self.assertIsNotNone(ua.ch)
             self.assertTrue(type(ua.ch.mobile) is str)
             self.assertEqual(ua.ch.mobile, '?0')
@@ -86,7 +86,7 @@ class TestClientHints(unittest.TestCase):
 
     def test_ch_bitness(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch)
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH)
             self.assertIsNotNone(ua.ch)
             self.assertTrue(type(ua.ch.bitness) is str)
             self.assertIn(ua.ch.bitness, ('"32"', '"64"'))
@@ -94,7 +94,7 @@ class TestClientHints(unittest.TestCase):
 
     def test_ch_architecture(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch)
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH)
             self.assertIsNotNone(ua.ch)
             self.assertTrue(type(ua.ch.architecture) is str)
             self.assertIn(ua.ch.architecture, ('"arm"', '"x86"'))

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -6,7 +6,7 @@ License: Apache License 2.0
 import unittest
 
 import src.ua_generator as ua_generator
-from src.ua_generator.data import browsers_support_ch
+from src.ua_generator.data import BROWSERS_SUPPORT_CH
 
 
 class TestHeaders(unittest.TestCase):
@@ -18,7 +18,7 @@ class TestHeaders(unittest.TestCase):
 
     def test_client_hints(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch)
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH)
             self.assertIsNotNone(ua.headers)
             self.assertTrue('sec-ch-ua' in ua.headers.get())
             self.assertTrue('sec-ch-ua-mobile' in ua.headers.get())
@@ -34,7 +34,7 @@ class TestHeaders(unittest.TestCase):
 
     def test_accept_ch(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch)
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH)
 
             ua.headers.accept_ch('Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List')
             self.assertTrue('sec-ch-ua-platform-version' in ua.headers.get())
@@ -52,7 +52,7 @@ class TestHeaders(unittest.TestCase):
 
     def test_reset(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch)
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH)
 
             ua.headers.add('sec-ch-ua-bitness')
             self.assertTrue('user-agent' in ua.headers.get())
@@ -66,7 +66,7 @@ class TestHeaders(unittest.TestCase):
 
     def test_accept_ch_not_exists(self):
         for i in range(0, 100):
-            ua = ua_generator.generate(browser=browsers_support_ch)
+            ua = ua_generator.generate(browser=BROWSERS_SUPPORT_CH)
             ua.headers.accept_ch('Sec-CH-Example')
             self.assertFalse('sec-ch-ua-platform-version' in ua.headers.get())
             self.assertFalse('sec-ch-ua-full-version-list' in ua.headers.get())

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -5,9 +5,10 @@ License: Apache License 2.0
 """
 import re
 import unittest
+from src.ua_generator.options import Options
 
 import src.ua_generator as ua_generator
-
+from src.ua_generator import exceptions 
 
 class TestUserAgent(unittest.TestCase):
     def test_user_agent(self):
@@ -58,7 +59,54 @@ class TestUserAgent(unittest.TestCase):
         for i in range(0, 200):
             ua = ua_generator.generate()
             self.assertNotRegex(ua.text, brackets)
+    def test_invalid_browser_version_range(self):
+        #Goal is to ensure the proper error(s) are raised when an invalid browser version range is specified
+        # Case 1: Chrome version range with 101 and 100 
+        options = Options(chrome_versions=(101, 100))
+        with self.assertRaises(exceptions.InvalidArgumentError):
+            ua_generator.generate(browser="chrome", options=options)
 
+        # Case 2: Chrome version range with 99 and 101 (99 is an invalid version)
+        options = Options(chrome_versions=(99, 101))
+        with self.assertRaises(exceptions.InvalidArgumentError):
+            ua_generator.generate(browser="chrome", options=options)
 
+        # Case 3: Firefox version range with 129 and 130 (130 not valid version)
+        options = Options(firefox_versions=(129, 130))
+        with self.assertRaises(exceptions.InvalidArgumentError):
+            ua_generator.generate(browser="firefox", options=options)
+
+        # Case 4: Edge version range with 106 and 102 (invalid range)
+        options = Options(edge_versions=(106, 102))
+        with self.assertRaises(exceptions.InvalidArgumentError):
+            ua_generator.generate(browser="edge", options=options)
+
+        # Case 5: Safari version range with 12 and 10 (invalid range)
+        options = Options(safari_versions=(12, 10))
+        with self.assertRaises(exceptions.InvalidArgumentError):
+            ua = ua_generator.generate(platform="macos", browser="safari", options=options)
+            print(ua.text)
+    
+    def test_valid_browser_version_ranges(self):
+    #Make sure proper browser version ranges are accepted
+        # Define the valid version ranges for each browser
+        valid_ranges = {
+            "chrome": (100, 127),  # Ranges from major version 100 to 127
+            "firefox": (103, 129),  # Ranges from major version 103 to 129
+            "edge": (100, 128),     # Ranges from major version 100 to 128
+            "safari": (10, 17)      # Ranges from major version 10 to 17
+        }
+
+        for browser, (min_version, max_version) in valid_ranges.items():
+            # Create Options instance with the valid version range
+            options = Options(**{f"{browser}_versions": (min_version, max_version)})
+
+            # Generate a user agent for the given browser and options
+            try:
+                ua = ua_generator.generate(browser=browser, options=options)
+            except exceptions.InvalidArgumentError as e:
+                self.fail(f"Unexpected InvalidArgumentError for {browser} with version range {min_version}-{max_version}: {str(e)}")
+          
+        
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,7 +5,7 @@ License: Apache License 2.0
 """
 import unittest
 
-from src.ua_generator.data.version import Version, WindowsVersion, AndroidVersion, ChromiumVersion
+from src.ua_generator.data.version import Version, WindowsVersion,AndroidVersion, ChromiumVersion
 
 
 class TestVersion(unittest.TestCase):
@@ -118,7 +118,5 @@ class TestVersion(unittest.TestCase):
         version = ChromiumVersion(Version(major=1, minor=2, build=3, patch=4), webkit=Version(537, 36))
         self.assertEqual(version.format(partitions=4), '1.2.3.4')
         self.assertEqual(version.webkit.format(), '537.36')
-
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Changes:

Centralized version data to data/__init__.py to avoid circular imports, also uppercased the constants.
Added support for browser version range specification in Options. Only up to the major.
Added browser version range validity check in user_agent.py as a part of __find_browser
Added index map of all browser versions at root __init__.py to ensure quick version lookups. This is an expensive operation so it is done only once at import.
Added a VersionRange class in Version for cleanliness.
Updated the browsers in data/browsers to support filter 'versions' based on specified version range. 
Added thorough unit tests to test all new functionality.

I notice there are two commits but its basically just the latter since i undid most of the changes in the first one upon your request.

Side note: new versions can be added seamlessly with this push in the future


Also we need to update the README if you plan to merge @iamdual 





