### PR TITLE
Typing literals + UserAgent __repr__

### DIFF
--- a/src/ua_generator/__init__.py
+++ b/src/ua_generator/__init__.py
@@ -5,11 +5,13 @@ License: Apache License 2.0
 """
 import typing
 
-from . import user_agent, options as _options
+from . import user_agent, options as _options, data as _data
 
 
-def generate(device: typing.Union[tuple, str, None] = None,
-             platform: typing.Union[tuple, str, None] = None,
-             browser: typing.Union[tuple, str, None] = None,
-             options: typing.Union[_options.Options, None] = None) -> user_agent.UserAgent:
+def generate(
+    device: typing.Union[tuple[_data._DEVICES_TYPE], _data._DEVICES_TYPE, None] = None,
+    platform: typing.Union[tuple[_data._PLATFORMS_TYPE], _data._PLATFORMS_TYPE, None] = None,
+    browser: typing.Union[tuple[_data._BROWSERS_TYPE], _data._BROWSERS_TYPE, None] = None,
+    options: typing.Union[_options.Options, None] = None
+):
     return user_agent.UserAgent(device, platform, browser, options)

--- a/src/ua_generator/data/__init__.py
+++ b/src/ua_generator/data/__init__.py
@@ -3,12 +3,17 @@ Random User-Agent
 Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
+from typing import Literal
 
 DEVICES = ('desktop', 'mobile')
+_DEVICES_TYPE = Literal['desktop', 'mobile', None]
 
 PLATFORMS = ('windows', 'macos', 'ios', 'linux', 'android')
+_PLATFORMS_TYPE = Literal['windows', 'macos', 'ios', 'linux', 'android', None]
 PLATFORMS_DESKTOP = ('windows', 'macos', 'linux')  # Platforms on desktop devices
 PLATFORMS_MOBILE = ('ios', 'android')  # Platforms on mobile devices
 
 BROWSERS = ('chrome', 'edge', 'firefox', 'safari')
+_BROWSERS_TYPE = Literal['chrome', 'edge', 'firefox', 'safari', None]
 BROWSERS_SUPPORT_CH = ('chrome', 'edge')  # Browsers that support Client Hints
+_BROWSERS_SUPPORT_CH_TYPE = Literal['chrome', 'edge', None]

--- a/src/ua_generator/user_agent.py
+++ b/src/ua_generator/user_agent.py
@@ -7,14 +7,26 @@ import typing
 
 from . import utils, exceptions
 from .client_hints import ClientHints
-from .data import DEVICES, BROWSERS, PLATFORMS, PLATFORMS_DESKTOP, PLATFORMS_MOBILE
+from .data import (
+    DEVICES, _DEVICES_TYPE,
+    BROWSERS, _BROWSERS_TYPE,
+    PLATFORMS, _PLATFORMS_TYPE,
+    PLATFORMS_DESKTOP,
+    PLATFORMS_MOBILE,
+)
 from .data.generator import Generator
 from .headers import Headers
 from .options import Options
 
 
 class UserAgent:
-    def __init__(self, device=None, platform=None, browser=None, options=None):
+    def __init__(
+        self,
+        device: _DEVICES_TYPE = None,
+        platform: _PLATFORMS_TYPE = None,
+        browser: _BROWSERS_TYPE = None,
+        options: typing.Union[Options, None] = None,
+    ):
         self.device: typing.Union[str, None] = utils.choice(device) if device else None
         self.platform: typing.Union[str, None] = utils.choice(platform) if platform else None
         self.browser: typing.Union[str, None] = utils.choice(browser) if browser else None
@@ -88,3 +100,6 @@ class UserAgent:
 
     def __str__(self):
         return self.text
+
+    def __repr__(self) -> str:
+        return f"UserAgent(\"{self.text}\", device={self.device}, platform={self.platform}, browser={self.browser})"


### PR DESCRIPTION
- I added type hints for strings to display the possible string values when generating an user agent:
   <img width="422" alt="Capture d’écran 2024-10-20 à 13 27 38" src="https://github.com/user-attachments/assets/70026e57-36ea-4400-ab71-807ced6f2631">
- Also added a `__repr__` method on the class to allow it to be displayed easily. We go from:
   <img width="483" alt="Capture d’écran 2024-10-20 à 13 30 00" src="https://github.com/user-attachments/assets/3d334d90-5d17-429e-8427-292fbf116fa2">
   To:
   <img width="1157" alt="Capture d’écran 2024-10-20 à 13 29 45" src="https://github.com/user-attachments/assets/5cbd4e20-b4dd-493f-a392-fe764b2d8db8">

   
