### PR TITLE
Usage of typing.Literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ device = ('desktop', 'mobile')
 platform = ('windows', 'macos', 'ios', 'linux', 'android')
 browser = ('chrome', 'edge', 'firefox', 'safari')
 ```
-_All parameters are optional and multiple types can be specified using a tuple._
+_All parameters are optional and multiple types can be specified using a list (or tuple)._
 ## Customized user-agent generation:
 
 ```python

--- a/src/ua_generator/__init__.py
+++ b/src/ua_generator/__init__.py
@@ -3,13 +3,13 @@ Random User-Agent
 Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
-import typing
+from typing import Union
 
-from . import user_agent, options as _options
+from . import user_agent, options as _options, data as _data
 
 
-def generate(device: typing.Union[tuple, str, None] = None,
-             platform: typing.Union[tuple, str, None] = None,
-             browser: typing.Union[tuple, str, None] = None,
-             options: typing.Union[_options.Options, None] = None) -> user_agent.UserAgent:
+def generate(device: Union[_data.T_DEVICES, tuple, list, None] = None,
+             platform: Union[_data.T_PLATFORMS, tuple, list, None] = None,
+             browser: Union[_data.T_BROWSERS, tuple, list, None] = None,
+             options: Union[_options.Options, None] = None) -> user_agent.UserAgent:
     return user_agent.UserAgent(device, platform, browser, options)

--- a/src/ua_generator/data/__init__.py
+++ b/src/ua_generator/data/__init__.py
@@ -3,12 +3,16 @@ Random User-Agent
 Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
+from typing import Literal
 
 DEVICES = ('desktop', 'mobile')
+T_DEVICES = Literal['desktop', 'mobile']
 
 PLATFORMS = ('windows', 'macos', 'ios', 'linux', 'android')
+T_PLATFORMS = Literal['windows', 'macos', 'ios', 'linux', 'android']
 PLATFORMS_DESKTOP = ('windows', 'macos', 'linux')  # Platforms on desktop devices
 PLATFORMS_MOBILE = ('ios', 'android')  # Platforms on mobile devices
 
 BROWSERS = ('chrome', 'edge', 'firefox', 'safari')
+T_BROWSERS = Literal['chrome', 'edge', 'firefox', 'safari']
 BROWSERS_SUPPORT_CH = ('chrome', 'edge')  # Browsers that support Client Hints

--- a/src/ua_generator/user_agent.py
+++ b/src/ua_generator/user_agent.py
@@ -3,21 +3,26 @@ Random User-Agent
 Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
-import typing
+from typing import Union
 
 from . import utils, exceptions
 from .client_hints import ClientHints
-from .data import DEVICES, BROWSERS, PLATFORMS, PLATFORMS_DESKTOP, PLATFORMS_MOBILE
+from .data import DEVICES, BROWSERS, PLATFORMS, PLATFORMS_DESKTOP, PLATFORMS_MOBILE, T_DEVICES, T_PLATFORMS, T_BROWSERS
 from .data.generator import Generator
 from .headers import Headers
 from .options import Options
 
 
 class UserAgent:
-    def __init__(self, device=None, platform=None, browser=None, options=None):
-        self.device: typing.Union[str, None] = utils.choice(device) if device else None
-        self.platform: typing.Union[str, None] = utils.choice(platform) if platform else None
-        self.browser: typing.Union[str, None] = utils.choice(browser) if browser else None
+    def __init__(self,
+                 device: Union[T_DEVICES, tuple, list, None] = None,
+                 platform: Union[T_PLATFORMS, tuple, list, None] = None,
+                 browser: Union[T_BROWSERS, tuple, list, None] = None,
+                 options: Union[Options, None] = None):
+
+        self.device: Union[str, None] = utils.choice(device) if device else None
+        self.platform: Union[str, None] = utils.choice(platform) if platform else None
+        self.browser: Union[str, None] = utils.choice(browser) if browser else None
         self.options: Options = options if options else Options()
         self.__complete()
 


### PR DESCRIPTION
After the deprecation of Python 3.6 and 3.7, we are now able to use `typing.Literal`.

This pull request brings back the changes from #15 by @novitae.
