### PR TITLE
Add Mypy Support and Improve Type Hinting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.package-data]
+ua_generator = ["py.typed"]

--- a/src/ua_generator/client_hints.py
+++ b/src/ua_generator/client_hints.py
@@ -4,6 +4,7 @@ Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 from random import Random
+from typing import Any
 
 from . import serialization
 from .data import generator, PLATFORMS_MOBILE
@@ -26,7 +27,7 @@ class ClientHints:
 
     def __init__(self, gen: generator.Generator):
         self.__generator = gen
-        self.__cache = {}
+        self.__cache: dict[str, Any] = {}
 
     def get_mobile(self) -> bool:
         return self.__generator.platform in PLATFORMS_MOBILE
@@ -44,8 +45,9 @@ class ClientHints:
         return platform
 
     def get_platform_version(self) -> str:
-        if type(self.__generator.platform_version) is WindowsVersion:
-            return self.__generator.platform_version.ch_platform.format(partitions=3)
+        if isinstance(self.__generator.platform_version, WindowsVersion):
+            if self.__generator.platform_version.ch_platform is not None:
+                return self.__generator.platform_version.ch_platform.format(partitions=3)
 
         return str(self.__generator.platform_version)
 

--- a/src/ua_generator/data/browsers/safari.py
+++ b/src/ua_generator/data/browsers/safari.py
@@ -6,7 +6,6 @@ License: Apache License 2.0
 import random
 from typing import List
 
-from ..filterer import Filterer
 from ..version import Version, ChromiumVersion
 from ...options import Options
 
@@ -25,6 +24,8 @@ versions: List[ChromiumVersion] = [
 
 
 def get_version(options: Options) -> ChromiumVersion:
+    from ..filterer import Filterer
+    
     filterer = Filterer(versions)
 
     if options.version_ranges and 'safari' in options.version_ranges:

--- a/src/ua_generator/data/platforms/android/android_oppo.py
+++ b/src/ua_generator/data/platforms/android/android_oppo.py
@@ -38,7 +38,14 @@ def get_version(options: Options) -> AndroidVersion:
         filterer.weighted_versions(max_range=3)
 
     choice: AndroidVersion = random.choice(filterer.versions)
-    choice.build_number = choice.build_number.replace('{d}', '{:02d}{:02d}{:02d}'.format(random.randint(22, 25), random.randint(0, 12), random.randint(0, 29)))
-    choice.build_number = choice.build_number.replace('{v}', '{}'.format(random.randint(1, 255)))
+    
+    if choice.build_number is not None:
+        choice.build_number = choice.build_number.replace('{d}', '{:02d}{:02d}{:02d}'.format(random.randint(22, 25), random.randint(0, 12), random.randint(0, 29)))
+        choice.build_number = choice.build_number.replace('{v}', '{}'.format(random.randint(1, 255)))
+    else:
+        date_part = '{:02d}{:02d}{:02d}'.format(random.randint(22, 25), random.randint(1, 12), random.randint(1, 28))
+        version_part = '{}'.format(random.randint(1, 255))
+        choice.build_number = f"DEFAULT.{date_part}.{version_part}"
+
     choice.platform_model = random.choice(platform_models)
     return choice

--- a/src/ua_generator/data/platforms/android/android_pixel.py
+++ b/src/ua_generator/data/platforms/android/android_pixel.py
@@ -40,7 +40,14 @@ def get_version(options: Options) -> AndroidVersion:
         filterer.weighted_versions(max_range=4)
 
     choice: AndroidVersion = random.choice(filterer.versions)
-    choice.build_number = choice.build_number.replace('{d}', '{:02d}{:02d}{:02d}'.format(random.randint(17, 25), random.randint(0, 12), random.randint(0, 29)))
-    choice.build_number = choice.build_number.replace('{v}', '{}'.format(random.randint(1, 255)))
+
+    if choice.build_number is not None:
+        choice.build_number = choice.build_number.replace('{d}', '{:02d}{:02d}{:02d}'.format(random.randint(17, 25), random.randint(0, 12), random.randint(0, 29)))
+        choice.build_number = choice.build_number.replace('{v}', '{}'.format(random.randint(1, 255)))
+    else:
+        date_part = '{:02d}{:02d}{:02d}'.format(random.randint(17, 25), random.randint(0, 12), random.randint(1, 28))
+        version_part = '{}'.format(random.randint(1, 255))
+        choice.build_number = f"DEFAULT.{date_part}.{version_part}"
+    
     choice.platform_model = random.choice(platform_models)
     return choice

--- a/src/ua_generator/data/platforms/android/android_samsung.py
+++ b/src/ua_generator/data/platforms/android/android_samsung.py
@@ -138,7 +138,14 @@ def get_version(options: Options) -> AndroidVersion:
         filterer.weighted_versions(max_range=5)
 
     choice: AndroidVersion = random.choice(filterer.versions)
-    choice.build_number = choice.build_number.replace('{d}', '{:02d}{:02d}{:02d}'.format(random.randint(17, 25), random.randint(0, 12), random.randint(0, 29)))
-    choice.build_number = choice.build_number.replace('{v}', '{}'.format(random.randint(1, 255)))
+    
+    if choice.build_number is not None:
+        choice.build_number = choice.build_number.replace('{d}', '{:02d}{:02d}{:02d}'.format(random.randint(17, 25), random.randint(1, 12), random.randint(1, 28))) 
+        choice.build_number = choice.build_number.replace('{v}', '{}'.format(random.randint(1, 255)))
+    else:
+        date_part = '{:02d}{:02d}{:02d}'.format(random.randint(17, 25), random.randint(1, 12), random.randint(1, 28))
+        version_part = '{}'.format(random.randint(1, 255))
+        choice.build_number = f"DEFAULT.{date_part}.{version_part}"
+
     choice.platform_model = random.choice(platform_models)
     return choice

--- a/src/ua_generator/data/platforms/android/android_xiaomi.py
+++ b/src/ua_generator/data/platforms/android/android_xiaomi.py
@@ -81,7 +81,13 @@ def get_version(options: Options) -> AndroidVersion:
         filterer.weighted_versions(max_range=3)
 
     choice: AndroidVersion = random.choice(filterer.versions)
-    choice.build_number = choice.build_number.replace('{d}', '{:02d}{:02d}{:02d}'.format(random.randint(22, 25), random.randint(0, 12), random.randint(0, 29)))
-    choice.build_number = choice.build_number.replace('{v}', '{}'.format(random.randint(1, 255)))
+    if choice.build_number is not None:
+        choice.build_number = choice.build_number.replace('{d}', '{:02d}{:02d}{:02d}'.format(random.randint(22, 25), random.randint(0, 12), random.randint(0, 29)))
+        choice.build_number = choice.build_number.replace('{v}', '{}'.format(random.randint(1, 255)))
+    else:
+        date_part = '{:02d}{:02d}{:02d}'.format(random.randint(22, 25), random.randint(1, 12), random.randint(1, 28))
+        version_part = '{}'.format(random.randint(1, 255))
+        choice.build_number = f"DEFAULT.{date_part}.{version_part}"
+        
     choice.platform_model = random.choice(platform_models)
     return choice

--- a/src/ua_generator/data/version.py
+++ b/src/ua_generator/data/version.py
@@ -4,29 +4,29 @@ Copyright: 2022-2025 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 import random
-from typing import Union, List
+from typing import Union, List, Optional
 
 from .. import utils
 
 
 class Version:
-    major: int | None = None
-    minor: int | None = None
-    build: int | None = None
-    patch: int | None = None
+    major: Optional[int] = None
+    minor: Optional[int] = None
+    build: Optional[int] = None
+    patch: Optional[int] = None
 
     def __init__(self,
-                 major: Union[int, tuple] | None = None,
-                 minor: Union[int, tuple] | None = None,
-                 build: Union[int, tuple] | None = None,
-                 patch: Union[int, tuple] | None = None):
+                 major: Optional[Union[int, tuple]] = None,
+                 minor: Optional[Union[int, tuple]]= None,
+                 build: Optional[Union[int, tuple]]= None,
+                 patch: Optional[Union[int, tuple]]= None):
         self.major, self.minor, self.build, self.patch = map(
             lambda x:
             # https://docs.python.org/3/tutorial/controlflow.html#tut-unpacking-arguments
             random.randrange(*x) if isinstance(x, tuple) else x,
             (major, minor, build, patch)
         )
-        self.__tuple : tuple[int, ...] | None = None
+        self.__tuple : Optional[tuple[int, ...]] = None
 
     def format(self, partitions=None, separator='.', trim_zero=False) -> str:
         versions = [self.major, self.minor, self.build, self.patch]
@@ -78,7 +78,7 @@ class Version:
 
 
 class ChromiumVersion(Version):
-    webkit: Version | None = None
+    webkit: Optional[Version] = None
 
     def __init__(self, version: Version, webkit: Version = Version(major=537, minor=36)):
         super().__init__(version.major, version.minor, version.build, version.patch)
@@ -86,8 +86,8 @@ class ChromiumVersion(Version):
 
 
 class AndroidVersion(Version):
-    build_number: str | None = None
-    platform_model: str | None = None
+    build_number: Optional[str] = None
+    platform_model: Optional[str] = None
 
     def __init__(self, version: Version, build_numbers: Union[str, tuple, list, None] = None):
         super().__init__(version.major, version.minor, version.build, version.patch)
@@ -95,7 +95,7 @@ class AndroidVersion(Version):
 
 
 class WindowsVersion(Version):
-    ch_platform: Version | None = None
+    ch_platform: Optional[Version] = None
 
     def __init__(self, version: Version, ch_platform: Version):
         super().__init__(version.major, version.minor, version.build, version.patch)
@@ -111,10 +111,10 @@ VERSION_TYPES = (
 
 
 class VersionRange:
-    min_version: Version | None = None
-    max_version: Version | None = None
+    min_version: Optional[Version] = None
+    max_version: Optional[Version] = None
 
-    def __init__(self, min_version: Union[Version, int] | None = None, max_version: Union[Version, int] | None = None):
+    def __init__(self, min_version: Optional[Union[Version, int]] = None, max_version: Optional[Union[Version, int]] = None):
         
         if isinstance(min_version, int):
             self.min_version = Version(major=min_version)

--- a/src/ua_generator/data/version.py
+++ b/src/ua_generator/data/version.py
@@ -151,9 +151,6 @@ class VersionRange:
                 if self.max_version.major is not None:
                     if version.major <= self.max_version.major:
                         include = True
-            
-            # elif self.min_version is None and self.max_version is None:
-            #     include = True
 
             if include:
                 tmp_versions.append(version)

--- a/src/ua_generator/data/version.py
+++ b/src/ua_generator/data/version.py
@@ -10,23 +10,23 @@ from .. import utils
 
 
 class Version:
-    major: int = None
-    minor: int = None
-    build: int = None
-    patch: int = None
+    major: int | None = None
+    minor: int | None = None
+    build: int | None = None
+    patch: int | None = None
 
     def __init__(self,
-                 major: Union[int, tuple] = None,
-                 minor: Union[int, tuple] = None,
-                 build: Union[int, tuple] = None,
-                 patch: Union[int, tuple] = None):
+                 major: Union[int, tuple] | None = None,
+                 minor: Union[int, tuple] | None = None,
+                 build: Union[int, tuple] | None = None,
+                 patch: Union[int, tuple] | None = None):
         self.major, self.minor, self.build, self.patch = map(
             lambda x:
             # https://docs.python.org/3/tutorial/controlflow.html#tut-unpacking-arguments
             random.randrange(*x) if isinstance(x, tuple) else x,
             (major, minor, build, patch)
         )
-        self.__tuple = None
+        self.__tuple : tuple[int, ...] | None = None
 
     def format(self, partitions=None, separator='.', trim_zero=False) -> str:
         versions = [self.major, self.minor, self.build, self.patch]
@@ -78,7 +78,7 @@ class Version:
 
 
 class ChromiumVersion(Version):
-    webkit: Version = None
+    webkit: Version | None = None
 
     def __init__(self, version: Version, webkit: Version = Version(major=537, minor=36)):
         super().__init__(version.major, version.minor, version.build, version.patch)
@@ -86,8 +86,8 @@ class ChromiumVersion(Version):
 
 
 class AndroidVersion(Version):
-    build_number: str = None
-    platform_model: str = None
+    build_number: str | None = None
+    platform_model: str | None = None
 
     def __init__(self, version: Version, build_numbers: Union[str, tuple, list, None] = None):
         super().__init__(version.major, version.minor, version.build, version.patch)
@@ -95,7 +95,7 @@ class AndroidVersion(Version):
 
 
 class WindowsVersion(Version):
-    ch_platform: Version = None
+    ch_platform: Version | None = None
 
     def __init__(self, version: Version, ch_platform: Version):
         super().__init__(version.major, version.minor, version.build, version.patch)
@@ -111,23 +111,51 @@ VERSION_TYPES = (
 
 
 class VersionRange:
-    min_version: Version = None
-    max_version: Version = None
+    min_version: Version | None = None
+    max_version: Version | None = None
 
-    def __init__(self, min_version: Union[Version, int] = None, max_version: Union[Version, int] = None):
-        self.min_version = Version(major=min_version) if type(min_version) is int else min_version
-        self.max_version = Version(major=max_version) if type(max_version) is int else max_version
+    def __init__(self, min_version: Union[Version, int] | None = None, max_version: Union[Version, int] | None = None):
+        
+        if isinstance(min_version, int):
+            self.min_version = Version(major=min_version)
+        else:
+            self.min_version = min_version
+        
+        if isinstance(max_version, int):
+            self.max_version = Version(major=max_version)
+        else:
+            self.max_version = max_version
 
     def filter(self, versions: List[Version]) -> List[Version]:
         tmp_versions: List[Version] = []
 
         # TODO: Perhaps support for full version comparison, instead of just major versions
         for version in versions:
-            if self.min_version is not None and self.max_version is not None and self.min_version.major <= version.major <= self.max_version.major:
-                tmp_versions.append(version)
-            elif self.min_version is not None and self.max_version is None and self.min_version.major <= version.major:
-                tmp_versions.append(version)
-            elif self.min_version is None and self.max_version is not None and version.major <= self.max_version.major:
+            if (version.major is None):
+                continue
+            
+            include = False
+            
+            if self.min_version is not None and self.max_version is not None:
+                
+                if self.min_version.major is not None and self.max_version.major is not None:
+                    if self.min_version.major <= version.major <= self.max_version.major:
+                        include = True
+            
+            elif self.min_version is not None and self.max_version is None:
+                if self.min_version.major is not None:
+                    if self.min_version.major <= version.major:
+                        include = True
+            
+            elif self.min_version is None and self.max_version is not None:
+                if self.max_version.major is not None:
+                    if version.major <= self.max_version.major:
+                        include = True
+            
+            # elif self.min_version is None and self.max_version is None:
+            #     include = True
+
+            if include:
                 tmp_versions.append(version)
 
         return tmp_versions

--- a/src/ua_generator/options.py
+++ b/src/ua_generator/options.py
@@ -10,9 +10,9 @@ from .data.version import VersionRange
 
 class Options:
     weighted_versions: bool = False
-    version_ranges: typing.Dict[str, VersionRange] = None
+    version_ranges: typing.Dict[str, VersionRange] | None = None
 
-    def __init__(self, weighted_versions: bool = False, version_ranges: typing.Dict[str, VersionRange] = None):
+    def __init__(self, weighted_versions: bool = False, version_ranges: typing.Dict[str, VersionRange] | None = None):
         self.weighted_versions = weighted_versions
         if version_ranges is not None:
             self.version_ranges = version_ranges

--- a/src/ua_generator/options.py
+++ b/src/ua_generator/options.py
@@ -10,9 +10,9 @@ from .data.version import VersionRange
 
 class Options:
     weighted_versions: bool = False
-    version_ranges: typing.Dict[str, VersionRange] | None = None
+    version_ranges: typing.Optional[typing.Dict[str, VersionRange]] = None
 
-    def __init__(self, weighted_versions: bool = False, version_ranges: typing.Dict[str, VersionRange] | None = None):
+    def __init__(self, weighted_versions: bool = False, version_ranges: typing.Optional[typing.Dict[str, VersionRange]] = None):
         self.weighted_versions = weighted_versions
         if version_ranges is not None:
             self.version_ranges = version_ranges

--- a/src/ua_generator/user_agent.py
+++ b/src/ua_generator/user_agent.py
@@ -45,7 +45,8 @@ class UserAgent:
 
         if self.device is None:
             self.device = utils.choice(DEVICES)
-
+        
+        assert isinstance(self.device, str), "Device should be string before returning"
         return self.device
 
     def __find_platform(self) -> str:
@@ -65,6 +66,7 @@ class UserAgent:
         if self.platform is None:
             self.platform = utils.choice(PLATFORMS)
 
+        assert isinstance(self.platform, str), "Platform should be string before returning"
         return self.platform
 
     def __find_browser(self) -> str:
@@ -78,6 +80,7 @@ class UserAgent:
         if self.browser == 'safari' and self.platform not in ('macos', 'ios'):
             self.browser = 'chrome'
 
+        assert isinstance(self.browser, str), "Browser should be string before returning"
         return self.browser
 
     def __complete(self):

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,4 +1,3 @@
-from typing import reveal_type
 import src.ua_generator as ua_generator
 
 def test_ua_generator():
@@ -11,4 +10,3 @@ def test_ua_generator():
     ```
     """
     agent = ua_generator.generate()
-    reveal_type(agent)

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,14 @@
+from typing import reveal_type
+import src.ua_generator as ua_generator
+
+def test_ua_generator():
+    """
+    This function is used to test mypy type hints.
+    
+    To test this function, run the following command:
+    ```bash
+      mypy tests/test_typing.py
+    ```
+    """
+    agent = ua_generator.generate()
+    reveal_type(agent)


### PR DESCRIPTION
This PR introduces static type checking support using Mypy and enhances the overall type hinting throughout the ua-generator library.

Key Changes:

- Added py.typed marker file: Includes the `py.typed` file in the src/ua_generator directory to signal PEP 561 compliance, allowing Mypy to recognize the package for type checking.
- Introduced Mypy Test: Added a new test file `test_typing.py` specifically for verifying type hints with Mypy. This includes instructions on how to run the check.
- Enhanced Type Annotations:
  - Added type hints to function signatures, return types, and variables across various modules, including `utils.py` , `client_hints.py` , `options.py` , and data modules within `data` .
  - Utilized types from the typing module like List , Dict , Union , Literal , and Any for better code clarity and correctness.
  - Improved type definitions within the `Version` class and its subclasses ( `ChromiumVersion` , `AndroidVersion` , `WindowsVersion` ).
 
These changes improve code maintainability, reduce potential runtime errors, and make the library easier to use correctly by providing clearer type information.