### PR TITLE
Make global variable "versions" uppercase

### DIFF
--- a/scripts/update-bot/chrome.py
+++ b/scripts/update-bot/chrome.py
@@ -15,7 +15,7 @@ parsed = json.loads(json_data)
 
 # Get versions
 versions_match = re.search(
-    r"(versions:\s+List\[ChromiumVersion\]\s*=\s*\[\n)(.*?)(\n\s*\])",
+    r"(VERSIONS:\s+List\[ChromiumVersion\]\s*=\s*\[\n)(.*?)(\n\s*\])",
     code,
     flags=re.DOTALL,
 )

--- a/scripts/update-bot/edge.py
+++ b/scripts/update-bot/edge.py
@@ -15,7 +15,7 @@ parsed = json.loads(json_data)
 
 # Get versions
 versions_match = re.search(
-    r"(versions:\s+List\[ChromiumVersion\]\s*=\s*\[\n)(.*?)(\n\s*\])",
+    r"(VERSIONS:\s+List\[ChromiumVersion\]\s*=\s*\[\n)(.*?)(\n\s*\])",
     code,
     flags=re.DOTALL,
 )

--- a/scripts/update-bot/firefox.py
+++ b/scripts/update-bot/firefox.py
@@ -15,7 +15,7 @@ parsed = json.loads(json_data)
 
 # Get versions
 versions_match = re.search(
-    r"(versions:\s+List\[Version\]\s*=\s*\[\n)(.*?)(\n\s*\])",
+    r"(VERSIONS:\s+List\[Version\]\s*=\s*\[\n)(.*?)(\n\s*\])",
     code,
     flags=re.DOTALL,
 )

--- a/scripts/update-bot/ios.py
+++ b/scripts/update-bot/ios.py
@@ -18,7 +18,7 @@ parsed = sorted(parsed, key=lambda p: float(p.get('cycle', 0)))
 
 # Get versions
 versions_match = re.search(
-    r"(versions:\s+List\[Version\]\s*=\s*\[\n)(.*?)(\n\s*\])",
+    r"(VERSIONS:\s+List\[Version\]\s*=\s*\[\n)(.*?)(\n\s*\])",
     code,
     flags=re.DOTALL,
 )

--- a/scripts/update-bot/macos.py
+++ b/scripts/update-bot/macos.py
@@ -18,7 +18,7 @@ parsed = sorted(parsed, key=lambda p: float(p.get('cycle', 0)))
 
 # Get versions
 versions_match = re.search(
-    r"(versions:\s+List\[Version\]\s*=\s*\[\n)(.*?)(\n\s*\])",
+    r"(VERSIONS:\s+List\[Version\]\s*=\s*\[\n)(.*?)(\n\s*\])",
     code,
     flags=re.DOTALL,
 )

--- a/src/ua_generator/data/browsers/chrome.py
+++ b/src/ua_generator/data/browsers/chrome.py
@@ -11,7 +11,7 @@ from ..version import Version, ChromiumVersion
 from ...options import Options
 
 # https://chromereleases.googleblog.com/search/label/Stable%20updates
-versions: List[ChromiumVersion] = [
+VERSIONS: List[ChromiumVersion] = [
     ChromiumVersion(Version(major=100, minor=0, build=4896, patch=(0, 255))),
     ChromiumVersion(Version(major=101, minor=0, build=4951, patch=(0, 255))),
     ChromiumVersion(Version(major=102, minor=0, build=5005, patch=(0, 255))),
@@ -55,7 +55,7 @@ versions: List[ChromiumVersion] = [
 
 
 def get_version(options: Options) -> ChromiumVersion:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'chrome' in options.version_ranges:
         filterer.version_range(options.version_ranges['chrome'])

--- a/src/ua_generator/data/browsers/edge.py
+++ b/src/ua_generator/data/browsers/edge.py
@@ -11,7 +11,7 @@ from ..version import Version, ChromiumVersion
 from ...options import Options
 
 # https://learn.microsoft.com/en-us/deployedge/microsoft-edge-release-schedule
-versions: List[ChromiumVersion] = [
+VERSIONS: List[ChromiumVersion] = [
     ChromiumVersion(Version(major=100, minor=0, build=1185, patch=(0, 99))),
     ChromiumVersion(Version(major=101, minor=0, build=1210, patch=(0, 99))),
     ChromiumVersion(Version(major=102, minor=0, build=1245, patch=(0, 99))),
@@ -55,7 +55,7 @@ versions: List[ChromiumVersion] = [
 
 
 def get_version(options: Options) -> ChromiumVersion:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'edge' in options.version_ranges:
         filterer.version_range(options.version_ranges['edge'])

--- a/src/ua_generator/data/browsers/firefox.py
+++ b/src/ua_generator/data/browsers/firefox.py
@@ -11,7 +11,7 @@ from ..version import Version
 from ...options import Options
 
 # https://www.mozilla.org/en-US/firefox/releases/
-versions: List[Version] = [
+VERSIONS: List[Version] = [
     Version(major=108, minor=0, build=(0, 2)),
     Version(major=109, minor=0, build=(0, 1)),
     Version(major=110, minor=0, build=(0, 1)),
@@ -64,7 +64,7 @@ versions: List[Version] = [
 
 
 def get_version(options: Options) -> Version:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'firefox' in options.version_ranges:
         filterer.version_range(options.version_ranges['firefox'])

--- a/src/ua_generator/data/browsers/safari.py
+++ b/src/ua_generator/data/browsers/safari.py
@@ -11,7 +11,7 @@ from ..version import Version, ChromiumVersion
 from ...options import Options
 
 # https://developer.apple.com/documentation/safari-release-notes
-versions: List[ChromiumVersion] = [
+VERSIONS: List[ChromiumVersion] = [
     ChromiumVersion(Version(major=10, minor=0), webkit=Version(major=602, minor=4, build=8)),
     ChromiumVersion(Version(major=11, minor=0), webkit=Version(major=604, minor=1, build=38)),
     ChromiumVersion(Version(major=12, minor=(0, 1)), webkit=Version(major=605, minor=1, build=15)),
@@ -25,7 +25,7 @@ versions: List[ChromiumVersion] = [
 
 
 def get_version(options: Options) -> ChromiumVersion:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'safari' in options.version_ranges:
         filterer.version_range(options.version_ranges['safari'])

--- a/src/ua_generator/data/platforms/android/android_oppo.py
+++ b/src/ua_generator/data/platforms/android/android_oppo.py
@@ -12,7 +12,7 @@ from ....options import Options
 
 # https://en.wikipedia.org/wiki/Android_version_history
 # https://source.android.com/docs/setup/reference/build-numbers
-versions: List[AndroidVersion] = [
+VERSIONS: List[AndroidVersion] = [
     AndroidVersion(Version(major=11, minor=0, build=0), build_numbers=('RD2A.{d}.{v}', 'RQ3A.{d}.{v}', 'RQ2A.{d}.{v}', 'RQ1D.{d}.{v}', 'RQ1C.{d}.{v}', 'RQ1A.{d}.{v}', 'RD1B.{d}.{v}', 'RD1A.{d}.{v}', 'RP1A.{d}.{v}')),
     AndroidVersion(Version(major=12, minor=0, build=0), build_numbers=('SP1A.{d}.{v}', 'SQ1D.{d}.{v}', 'SD1A.{d}.{v}')),
     AndroidVersion(Version(major=12, minor=1, build=0), build_numbers=('SP2A.{d}.{v}', 'SD2A.{d}.{v}', 'SQ3A.{d}.{v}')),
@@ -30,7 +30,7 @@ platform_models = ('CH1933', 'CPH2195', 'CPH2263', 'CPH1941', 'CPH2021', 'CPH221
 
 
 def get_version(options: Options) -> AndroidVersion:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'android' in options.version_ranges:
         filterer.version_range(options.version_ranges['android'])

--- a/src/ua_generator/data/platforms/android/android_pixel.py
+++ b/src/ua_generator/data/platforms/android/android_pixel.py
@@ -14,7 +14,7 @@ from ....options import Options
 # https://en.wikipedia.org/wiki/Google_Pixel
 # https://developers.google.com/android/images
 # https://source.android.com/docs/setup/reference/build-numbers
-versions: List[AndroidVersion] = [
+VERSIONS: List[AndroidVersion] = [
     AndroidVersion(Version(major=8, minor=0, build=0), build_numbers=('OPR6.{d}.{v}', 'OPR5.{d}.{v}', 'OPR4.{d}.{v}', 'OPR3.{d}.{v}', 'OPR2.{d}.{v}', 'OPR1.{d}.{v}', 'OPD3.{d}.{v}', 'OPD2.{d}.{v}', 'OPD1.{d}.{v}')),
     AndroidVersion(Version(major=8, minor=1, build=0), build_numbers=('OPM8.{d}.{v}', 'OPM7.{d}.{v}', 'OPM6.{d}.{v}', 'OPM5.{d}.{v}', 'OPM4.{d}.{v}', 'OPM3.{d}.{v}', 'OPM2.{d}.{v}')),
     AndroidVersion(Version(major=9, minor=0, build=0), build_numbers=('PQ3B.{d}.{v}', 'PQ3A.{d}.{v}', 'PQ2A.{d}.{v}', 'PQ1A.{d}.{v}', 'PPR2.{d}.{v}', 'PPR1.{d}.{v}')),
@@ -39,7 +39,7 @@ platform_models = ('Pixel 2', 'Pixel 2 XL',
 
 
 def get_version(options: Options) -> AndroidVersion:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'android' in options.version_ranges:
         filterer.version_range(options.version_ranges['android'])

--- a/src/ua_generator/data/platforms/android/android_samsung.py
+++ b/src/ua_generator/data/platforms/android/android_samsung.py
@@ -12,7 +12,7 @@ from ....options import Options
 
 # https://en.wikipedia.org/wiki/Android_version_history
 # https://source.android.com/docs/setup/reference/build-numbers
-versions: List[AndroidVersion] = [
+VERSIONS: List[AndroidVersion] = [
     AndroidVersion(Version(major=8, minor=0, build=0), build_numbers=('OPR6.{d}.{v}', 'OPR5.{d}.{v}', 'OPR4.{d}.{v}', 'OPR3.{d}.{v}', 'OPR2.{d}.{v}', 'OPR1.{d}.{v}', 'OPD3.{d}.{v}', 'OPD2.{d}.{v}', 'OPD1.{d}.{v}')),
     AndroidVersion(Version(major=8, minor=1, build=0), build_numbers=('OPM8.{d}.{v}', 'OPM7.{d}.{v}', 'OPM6.{d}.{v}', 'OPM5.{d}.{v}', 'OPM4.{d}.{v}', 'OPM3.{d}.{v}', 'OPM2.{d}.{v}')),
     AndroidVersion(Version(major=9, minor=0, build=0), build_numbers=('PQ3B.{d}.{v}', 'PQ3A.{d}.{v}', 'PQ2A.{d}.{v}', 'PQ1A.{d}.{v}', 'PPR2.{d}.{v}', 'PPR1.{d}.{v}')),
@@ -130,7 +130,7 @@ platform_models = ('SM-G390Y', 'SM-G390Y', 'SM-G525F', 'SM-G9006W', 'SM-G9209K',
 
 
 def get_version(options: Options) -> AndroidVersion:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'android' in options.version_ranges:
         filterer.version_range(options.version_ranges['android'])

--- a/src/ua_generator/data/platforms/android/android_xiaomi.py
+++ b/src/ua_generator/data/platforms/android/android_xiaomi.py
@@ -12,7 +12,7 @@ from ....options import Options
 
 # https://en.wikipedia.org/wiki/Android_version_history
 # https://source.android.com/docs/setup/reference/build-numbers
-versions: List[AndroidVersion] = [
+VERSIONS: List[AndroidVersion] = [
     AndroidVersion(Version(major=8, minor=0, build=0), build_numbers=('OPR6.{d}.{v}', 'OPR5.{d}.{v}', 'OPR4.{d}.{v}', 'OPR3.{d}.{v}', 'OPR2.{d}.{v}', 'OPR1.{d}.{v}', 'OPD3.{d}.{v}', 'OPD2.{d}.{v}', 'OPD1.{d}.{v}')),
     AndroidVersion(Version(major=8, minor=1, build=0), build_numbers=('OPM8.{d}.{v}', 'OPM7.{d}.{v}', 'OPM6.{d}.{v}', 'OPM5.{d}.{v}', 'OPM4.{d}.{v}', 'OPM3.{d}.{v}', 'OPM2.{d}.{v}')),
     AndroidVersion(Version(major=9, minor=0, build=0), build_numbers=('PQ3B.{d}.{v}', 'PQ3A.{d}.{v}', 'PQ2A.{d}.{v}', 'PQ1A.{d}.{v}', 'PPR2.{d}.{v}', 'PPR1.{d}.{v}')),
@@ -72,7 +72,7 @@ platform_models = (
 
 
 def get_version(options: Options) -> AndroidVersion:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'android' in options.version_ranges:
         filterer.version_range(options.version_ranges['android'])

--- a/src/ua_generator/data/platforms/ios.py
+++ b/src/ua_generator/data/platforms/ios.py
@@ -13,7 +13,7 @@ from ...options import Options
 # https://developer.apple.com/documentation/ios-ipados-release-notes
 # https://developer.apple.com/news/releases/
 # https://support.apple.com/en-us/HT201222
-versions: List[Version] = [
+VERSIONS: List[Version] = [
     Version(major=14, minor=0, build=(0, 1)),
     Version(major=14, minor=1, build=0),
     Version(major=14, minor=2, build=(0, 1)),
@@ -55,7 +55,7 @@ versions: List[Version] = [
 
 
 def get_version(options: Options) -> Version:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'ios' in options.version_ranges:
         filterer.version_range(options.version_ranges['ios'])

--- a/src/ua_generator/data/platforms/linux.py
+++ b/src/ua_generator/data/platforms/linux.py
@@ -11,7 +11,7 @@ from ..version import Version
 from ...options import Options
 
 # https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/refs/
-versions: List[Version] = [
+VERSIONS: List[Version] = [
     Version(major=5, minor=0, build=(0, 21)),
     Version(major=5, minor=1, build=(0, 21)),
     Version(major=5, minor=2, build=(0, 20)),
@@ -51,7 +51,7 @@ versions: List[Version] = [
 
 
 def get_version(options: Options) -> Version:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'linux' in options.version_ranges:
         filterer.version_range(options.version_ranges['linux'])

--- a/src/ua_generator/data/platforms/macos.py
+++ b/src/ua_generator/data/platforms/macos.py
@@ -15,7 +15,7 @@ from ...options import Options
 
 # https://developer.apple.com/news/releases/
 # https://support.apple.com/en-us/HT201222
-versions: List[Version] = [
+VERSIONS: List[Version] = [
     Version(major=10, minor=11, build=(0, 6)),
     Version(major=10, minor=12, build=(0, 6)),
     Version(major=10, minor=13, build=(0, 6)),
@@ -61,7 +61,7 @@ versions: List[Version] = [
 
 
 def get_version(options: Options) -> Version:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'macos' in options.version_ranges:
         filterer.version_range(options.version_ranges['macos'])

--- a/src/ua_generator/data/platforms/windows.py
+++ b/src/ua_generator/data/platforms/windows.py
@@ -12,7 +12,7 @@ from ...options import Options
 
 # https://learn.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version
 # https://learn.microsoft.com/en-us/microsoft-edge/web-platform/how-to-detect-win11
-versions: List[WindowsVersion] = [
+VERSIONS: List[WindowsVersion] = [
     WindowsVersion(Version(major=6, minor=1), ch_platform=Version(major=0)),
     WindowsVersion(Version(major=6, minor=2), ch_platform=Version(major=0)),
     WindowsVersion(Version(major=6, minor=3), ch_platform=Version(major=0)),
@@ -22,7 +22,7 @@ versions: List[WindowsVersion] = [
 
 
 def get_version(options: Options) -> WindowsVersion:
-    filterer = Filterer(versions)
+    filterer = Filterer(VERSIONS)
 
     if options.version_ranges and 'windows' in options.version_ranges:
         filterer.version_range(options.version_ranges['windows'])

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -6,7 +6,7 @@ License: Apache License 2.0
 import unittest
 
 import src.ua_generator as ua_generator
-from src.ua_generator.data.browsers.chrome import versions as chrome_versions
+from src.ua_generator.data.browsers.chrome import VERSIONS as CHROME_VERSIONS
 from src.ua_generator.data.filterer import Filterer
 
 
@@ -59,7 +59,7 @@ class TestExceptions(unittest.TestCase):
 
     def test_type_error(self):
         def raised_call():
-            filterer = Filterer(chrome_versions)
+            filterer = Filterer(CHROME_VERSIONS)
             filterer.version_range(range(0, 2))
 
         self.assertRaises(TypeError, raised_call)

--- a/tests/test_filterer.py
+++ b/tests/test_filterer.py
@@ -5,26 +5,26 @@ License: Apache License 2.0
 """
 import unittest
 
-from src.ua_generator.data.browsers.chrome import versions as chrome_versions
+from src.ua_generator.data.browsers.chrome import VERSIONS as CHROME_VERSIONS
 from src.ua_generator.data.filterer import Filterer
 from src.ua_generator.data.version import VersionRange
 
 
 class TestFilterer(unittest.TestCase):
     def test_unfiltered(self):
-        filterer = Filterer(chrome_versions)
-        self.assertEqual(len(filterer.versions), len(chrome_versions))
+        filterer = Filterer(CHROME_VERSIONS)
+        self.assertEqual(len(filterer.versions), len(CHROME_VERSIONS))
 
     def test_version_range(self):
         CHROME_MIN = 131
         CHROME_MAX = 135
 
-        filterer = Filterer(chrome_versions)
+        filterer = Filterer(CHROME_VERSIONS)
         filterer.version_range(VersionRange(CHROME_MIN, CHROME_MAX))
         self.assertEqual(len(filterer.versions), (CHROME_MAX - CHROME_MIN) + 1)
 
     def test_weighted_versions(self):
-        filterer = Filterer(chrome_versions)
+        filterer = Filterer(CHROME_VERSIONS)
         filterer.weighted_versions()
         self.assertEqual(len(filterer.versions), 1)
 


### PR DESCRIPTION
Initially the use of "versions" wasn't intended for external usage, but going forward we need to make it uppercase. Also, the variable isn't mentioned in the documentation, so it shouldn't be considered a breaking change.