### PR TITLE
Add support to minor version set

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,14 @@ To choose only versions within specified ranges. Default is `None`.
 ```python
 import ua_generator
 from ua_generator.options import Options
-from ua_generator.data.version import VersionRange
+from ua_generator.data.version import Version, VersionRange
 
 # Choosing only versions within specified ranges
 options = Options()
 options.version_ranges = {
     'chrome': VersionRange(125, 129),  # Choose version between 125 and 129
     'edge': VersionRange(min_version=120),  # Choose version 120 minimum
+    'macos': VersionRange(max_version=Version(10, 15, 7)),  # Choose macOS 10.15.7 maximum
 }
 ua = ua_generator.generate(browser='chrome', options=options)
 ```

--- a/src/ua_generator/data/version.py
+++ b/src/ua_generator/data/version.py
@@ -132,16 +132,36 @@ class VersionRange:
         self.min_version = Version(major=min_version) if isinstance(min_version, int) else min_version
         self.max_version = Version(major=max_version) if isinstance(max_version, int) else max_version
 
+    @staticmethod
+    def _lower_bound(version: Version) -> tuple:
+        return tuple(
+            resolved_part if original_part is not None else 0
+            for original_part, resolved_part in zip(version.original, version.to_tuple())
+        )
+
+    @staticmethod
+    def _upper_bound(version: Version) -> tuple:
+        # Treat omitted components as wildcards for upper bounds. This keeps
+        # VersionRange(125, 129) matching every 129.x release, while letting
+        # Version(10, 15, 7) cap macOS at 10.15.7.
+        return tuple(
+            resolved_part if original_part is not None else 10 ** 9
+            for original_part, resolved_part in zip(version.original, version.to_tuple())
+        )
+
     def filter(self, versions: List[Version]) -> List[Version]:
         tmp_versions: List[Version] = []
 
-        # TODO: Perhaps support for full version comparison, instead of just major versions
+        min_version = self._lower_bound(self.min_version) if self.min_version is not None else None
+        max_version = self._upper_bound(self.max_version) if self.max_version is not None else None
+
         for version in versions:
-            if isinstance(self.min_version, Version) and isinstance(self.max_version, Version) and self.min_version.major <= int(version.major or 0) <= self.max_version.major: # type: ignore[operator]
-                tmp_versions.append(version)
-            elif isinstance(self.min_version, Version) and self.max_version is None and self.min_version.major <= int(version.major or 0): # type: ignore[operator]
-                tmp_versions.append(version)
-            elif self.min_version is None and isinstance(self.max_version, Version) and int(version.major or 0) <= self.max_version.major: # type: ignore[operator]
+            version_tuple = version.to_tuple()
+            if min_version is not None and version_tuple < min_version:
+                continue
+            if max_version is not None and version_tuple > max_version:
+                continue
+            if min_version is not None or max_version is not None:
                 tmp_versions.append(version)
 
         return tmp_versions

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -134,6 +134,41 @@ class TestVersionRange(unittest.TestCase):
             self.assertIsNotNone(ua.generator.browser_version)
             self.assertTrue(ua.generator.browser_version.major <= CHROME_MAX)
 
+    def test_version_range_int_bounds_include_entire_major_version(self):
+        versions = [
+            Version(major=124, minor=0, build=1),
+            Version(major=125, minor=0, build=99),
+            Version(major=126, minor=0, build=99),
+            Version(major=127, minor=0, build=99),
+            Version(major=128, minor=0, build=1),
+        ]
+
+        filtered = VersionRange(125, 127).filter(versions)
+
+        self.assertEqual(
+            [version.format(partitions=3) for version in filtered],
+            ['125.0.99', '126.0.99', '127.0.99'],
+        )
+
+    def test_version_range_supports_full_version_bounds(self):
+        versions = [
+            Version(major=10, minor=14, build=6),
+            Version(major=10, minor=15, build=1),
+            Version(major=10, minor=15, build=7),
+            Version(major=10, minor=15, build=8),
+            Version(major=11, minor=0, build=0),
+        ]
+
+        filtered = VersionRange(
+            min_version=Version(major=10, minor=15),
+            max_version=Version(major=10, minor=15, build=7),
+        ).filter(versions)
+
+        self.assertEqual(
+            [version.format(partitions=3) for version in filtered],
+            ['10.15.1', '10.15.7'],
+        )
+
     def test_version_range_invalid(self):
         # MUST be INVALID version range
         EDGE_MIN_INVALID = 1


### PR DESCRIPTION
Hey @iamdual,

I have added support to set the minor version, as on macOS there is a cap on the User Agent version at `10_15_7`, but apparently not on iOS ¯\\_(ツ)_/¯

Source: [[Chrome User-Agent Reduction](https://chromestatus.com/feature/5452592194781184)]

Thanks.