### PR TITLE
Add option: latest_versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,29 @@ ua = ua_generator.generate(browser='chrome', options=options)
 
 _Note: If there is no valid version within the range you set, the filter will just skip it and return a random valid version instead._
 
+## latest_versions
+To choose only the latest version, or one of the latest `N` versions for specified browsers or platforms. Default is `False`.
+
+```python
+import ua_generator
+from ua_generator.options import Options
+
+# Choose only the latest version for every browser and platform
+options = Options()
+options.latest_versions = True
+ua = ua_generator.generate(options=options)
+
+# Choose one of the latest N versions for specified browsers and platforms
+options = Options()
+options.latest_versions = {
+    'chrome': 3,
+    'firefox': 1,
+    'ios': 3,
+    'macos': 1,
+}
+ua = ua_generator.generate(browser='chrome', platform='ios', options=options)
+```
+
 ## tied_safari_version
 To make Safari version tied to macOS/iOS version. Default is `False`.
 

--- a/src/ua_generator/data/browsers/chrome.py
+++ b/src/ua_generator/data/browsers/chrome.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import random
@@ -64,12 +64,6 @@ VERSIONS: List[ChromiumVersion] = [
 
 
 def get_version(options: Options) -> ChromiumVersion:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'chrome' in options.version_ranges:
-        filterer.version_range(options.version_ranges['chrome'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions()
+    filterer = Filterer(VERSIONS, 'chrome', options)
 
     return random.choice(filterer.versions)

--- a/src/ua_generator/data/browsers/edge.py
+++ b/src/ua_generator/data/browsers/edge.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import random
@@ -64,12 +64,6 @@ VERSIONS: List[ChromiumVersion] = [
 
 
 def get_version(options: Options) -> ChromiumVersion:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'edge' in options.version_ranges:
-        filterer.version_range(options.version_ranges['edge'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions()
+    filterer = Filterer(VERSIONS, 'edge', options)
 
     return random.choice(filterer.versions)

--- a/src/ua_generator/data/browsers/firefox.py
+++ b/src/ua_generator/data/browsers/firefox.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import random
@@ -73,12 +73,6 @@ VERSIONS: List[Version] = [
 
 
 def get_version(options: Options) -> Version:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'firefox' in options.version_ranges:
-        filterer.version_range(options.version_ranges['firefox'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions()
+    filterer = Filterer(VERSIONS, 'firefox', options)
 
     return random.choice(filterer.versions)

--- a/src/ua_generator/data/browsers/safari.py
+++ b/src/ua_generator/data/browsers/safari.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import random
@@ -29,12 +29,6 @@ def get_version(options: Options, platform_version: Version) -> SafariVersion:
     if options.tied_safari_version:
         return SafariVersion(platform_version)
 
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'safari' in options.version_ranges:
-        filterer.version_range(options.version_ranges['safari'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions(max_range=3)
+    filterer = Filterer(VERSIONS, 'safari', options, max_weighted_version=3)
 
     return random.choice(filterer.versions)

--- a/src/ua_generator/data/filterer.py
+++ b/src/ua_generator/data/filterer.py
@@ -1,13 +1,18 @@
 import random
 
 from ..data.version import VersionRange
+from ..options import Options
 
 
 class Filterer:
-    def __init__(self, versions):
+    def __init__(self, versions, version_id: str, options: Options, max_weighted_version=4):
         self.versions = versions
+        self._version_id = version_id
+        self._options = options
+        self._max_weighted_version = max_weighted_version
+        self.apply_options()
 
-    def version_range(self, v_range: VersionRange):
+    def _version_range(self, v_range: VersionRange):
         if not isinstance(v_range, VersionRange):
             raise TypeError('Parameter v_range must be type of VersionRange')
 
@@ -15,10 +20,32 @@ class Filterer:
         if len(filtered) > 0:
             self.versions = filtered
 
-    def weighted_versions(self, weights=None, max_range=4):
-        if weights is None:
-            weights = [1.0] * len(self.versions)
-            for i in range(1, min(max_range, len(self.versions))):
-                weights[-i] = 10.0 - i
+    def _latest_versions(self, limit=1):
+        if not isinstance(limit, int) or isinstance(limit, bool):
+            raise TypeError('Parameter limit must be type of int')
+        if limit < 1:
+            raise ValueError('Parameter limit must be greater than 0')
+
+        self.versions = self.versions[-limit:]
+
+    def _weighted_version(self):
+        if not self._options.weighted_versions:
+            return
+
+        weights = [1.0] * len(self.versions)
+        for i in range(1, min(self._max_weighted_version, len(self.versions))):
+            weights[-i] = 10.0 - i
 
         self.versions = random.choices(self.versions, weights=weights, k=1)
+
+    def apply_options(self):
+        if self._options.version_ranges and self._version_id in self._options.version_ranges:
+            self._version_range(self._options.version_ranges[self._version_id])
+
+        latest_version_limit = self._options.latest_version_limit(self._version_id)
+        if latest_version_limit is not None:
+            self._latest_versions(latest_version_limit)
+
+        self._weighted_version()
+
+        return self

--- a/src/ua_generator/data/platforms/android/android_oppo.py
+++ b/src/ua_generator/data/platforms/android/android_oppo.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2025 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 import random
@@ -30,13 +30,7 @@ platform_models = ('CH1933', 'CPH2195', 'CPH2263', 'CPH1941', 'CPH2021', 'CPH221
 
 
 def get_version(options: Options) -> AndroidVersion:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'android' in options.version_ranges:
-        filterer.version_range(options.version_ranges['android'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions(max_range=3)
+    filterer = Filterer(VERSIONS, 'android', options, max_weighted_version=3)
 
     choice: AndroidVersion = random.choice(filterer.versions)
     if choice.build_number is not None:

--- a/src/ua_generator/data/platforms/android/android_pixel.py
+++ b/src/ua_generator/data/platforms/android/android_pixel.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2025 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 import random
@@ -39,13 +39,7 @@ platform_models = ('Pixel 2', 'Pixel 2 XL',
 
 
 def get_version(options: Options) -> AndroidVersion:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'android' in options.version_ranges:
-        filterer.version_range(options.version_ranges['android'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions(max_range=4)
+    filterer = Filterer(VERSIONS, 'android', options)
 
     choice: AndroidVersion = random.choice(filterer.versions)
     if choice.build_number is not None:

--- a/src/ua_generator/data/platforms/android/android_samsung.py
+++ b/src/ua_generator/data/platforms/android/android_samsung.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2025 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 import random
@@ -130,13 +130,7 @@ platform_models = ('SM-G390Y', 'SM-G390Y', 'SM-G525F', 'SM-G9006W', 'SM-G9209K',
 
 
 def get_version(options: Options) -> AndroidVersion:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'android' in options.version_ranges:
-        filterer.version_range(options.version_ranges['android'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions(max_range=5)
+    filterer = Filterer(VERSIONS, 'android', options, max_weighted_version=5)
 
     choice: AndroidVersion = random.choice(filterer.versions)
     if choice.build_number is not None:

--- a/src/ua_generator/data/platforms/android/android_xiaomi.py
+++ b/src/ua_generator/data/platforms/android/android_xiaomi.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2025 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
 import random
@@ -72,13 +72,7 @@ platform_models = (
 
 
 def get_version(options: Options) -> AndroidVersion:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'android' in options.version_ranges:
-        filterer.version_range(options.version_ranges['android'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions(max_range=3)
+    filterer = Filterer(VERSIONS, 'android', options, max_weighted_version=3)
 
     choice: AndroidVersion = random.choice(filterer.versions)
     if choice.build_number is not None:

--- a/src/ua_generator/data/platforms/ios.py
+++ b/src/ua_generator/data/platforms/ios.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import random
@@ -61,12 +61,6 @@ VERSIONS: List[Version] = [
 
 
 def get_version(options: Options) -> Version:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'ios' in options.version_ranges:
-        filterer.version_range(options.version_ranges['ios'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions()
+    filterer = Filterer(VERSIONS, 'ios', options)
 
     return random.choice(filterer.versions)

--- a/src/ua_generator/data/platforms/linux.py
+++ b/src/ua_generator/data/platforms/linux.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import random
@@ -51,12 +51,6 @@ VERSIONS: List[Version] = [
 
 
 def get_version(options: Options) -> Version:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'linux' in options.version_ranges:
-        filterer.version_range(options.version_ranges['linux'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions()
+    filterer = Filterer(VERSIONS, 'linux', options)
 
     return random.choice(filterer.versions)

--- a/src/ua_generator/data/platforms/macos.py
+++ b/src/ua_generator/data/platforms/macos.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import random
@@ -68,12 +68,6 @@ VERSIONS: List[Version] = [
 
 
 def get_version(options: Options) -> Version:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'macos' in options.version_ranges:
-        filterer.version_range(options.version_ranges['macos'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions()
+    filterer = Filterer(VERSIONS, 'macos', options)
 
     return random.choice(filterer.versions)

--- a/src/ua_generator/data/platforms/windows.py
+++ b/src/ua_generator/data/platforms/windows.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022-2025 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import random
@@ -22,12 +22,6 @@ VERSIONS: List[WindowsVersion] = [
 
 
 def get_version(options: Options) -> WindowsVersion:
-    filterer = Filterer(VERSIONS)
-
-    if options.version_ranges and 'windows' in options.version_ranges:
-        filterer.version_range(options.version_ranges['windows'])
-
-    if options.weighted_versions:
-        filterer.weighted_versions(max_range=2)
+    filterer = Filterer(VERSIONS, 'windows', options, max_weighted_version=2)
 
     return random.choice(filterer.versions)

--- a/src/ua_generator/options.py
+++ b/src/ua_generator/options.py
@@ -1,9 +1,9 @@
 """
 Random User-Agent
-Copyright: 2022-2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0
 """
-from typing import Optional
+from typing import Optional, Union
 
 from .data.version import VersionRange
 
@@ -11,26 +11,56 @@ from .data.version import VersionRange
 class Options:
     weighted_versions: bool = False
     version_ranges: Optional[dict[str, VersionRange]] = None
+    latest_versions: Union[bool, dict[str, int]] = False
     tied_safari_version: bool = False
 
     """
-    Argument usages like `Options(weighted_versions=)` and `Options(version_ranges=)` are deprecated.
-    Use options as variables instead:
-        ```
-        options = Options()
-        options.weighted_versions = True
-        options.tied_safari_version = True
-        options.version_ranges = {
+    Options can be configured with constructor arguments:
+    ```
+    options = Options(
+        weighted_versions=True,
+        tied_safari_version=True,
+        latest_versions={
+            'chrome': 3,
+            'macos': 1,
+        },
+        version_ranges={
             'chrome': VersionRange(125, 129),
             'edge': VersionRange(min_version=120),
-        }
-        ua = ua_generator.generate(options=options)
-        ```
+        },
+    )
+    ua = ua_generator.generate(options=options)
+    ```
     """
-    def __init__(self, weighted_versions: bool = False, version_ranges: Optional[dict[str, VersionRange]] = None):
+
+    def __init__(self,
+                 weighted_versions: bool = False,
+                 tied_safari_version: bool = False,
+                 latest_versions: Union[bool, dict[str, int]] = False,
+                 version_ranges: Optional[dict[str, VersionRange]] = None):
         self.weighted_versions = weighted_versions
+        self.tied_safari_version = tied_safari_version
+        self.latest_versions = latest_versions
         if version_ranges is not None:
             self.version_ranges = version_ranges
+
+    def latest_version_limit(self, key: str) -> Optional[int]:
+        if isinstance(self.latest_versions, bool):
+            return 1 if self.latest_versions else None
+
+        if not isinstance(self.latest_versions, dict):
+            raise TypeError('Parameter latest_versions must be type of bool or dict')
+
+        if key not in self.latest_versions:
+            return None
+
+        limit = self.latest_versions[key]
+        if not isinstance(limit, int) or isinstance(limit, bool):
+            raise TypeError('Parameter latest_versions values must be type of int')
+        if limit < 1:
+            raise ValueError('Parameter latest_versions values must be greater than 0')
+
+        return limit
 
     def __repr__(self):
         v = []

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2022 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2022-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import unittest
@@ -8,6 +8,7 @@ import unittest
 import src.ua_generator as ua_generator
 from src.ua_generator.data.browsers.chrome import VERSIONS as CHROME_VERSIONS
 from src.ua_generator.data.filterer import Filterer
+from src.ua_generator.options import Options
 
 
 class TestExceptions(unittest.TestCase):
@@ -59,8 +60,7 @@ class TestExceptions(unittest.TestCase):
 
     def test_type_error(self):
         def raised_call():
-            filterer = Filterer(CHROME_VERSIONS)
-            filterer.version_range(range(0, 2))
+            Filterer(CHROME_VERSIONS, 'chrome', Options(version_ranges={'chrome': range(0, 2)}))
 
         self.assertRaises(TypeError, raised_call)
 

--- a/tests/test_filterer.py
+++ b/tests/test_filterer.py
@@ -1,6 +1,6 @@
 """
 Random User-Agent
-Copyright: 2025 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2025-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import unittest
@@ -8,24 +8,40 @@ import unittest
 from src.ua_generator.data.browsers.chrome import VERSIONS as CHROME_VERSIONS
 from src.ua_generator.data.filterer import Filterer
 from src.ua_generator.data.version import VersionRange
+from src.ua_generator.options import Options
 
 
 class TestFilterer(unittest.TestCase):
     def test_unfiltered(self):
-        filterer = Filterer(CHROME_VERSIONS)
+        filterer = Filterer(CHROME_VERSIONS, 'chrome', Options())
         self.assertEqual(len(filterer.versions), len(CHROME_VERSIONS))
 
     def test_version_range(self):
         CHROME_MIN = 131
         CHROME_MAX = 135
 
-        filterer = Filterer(CHROME_VERSIONS)
-        filterer.version_range(VersionRange(CHROME_MIN, CHROME_MAX))
+        options = Options(version_ranges={'chrome': VersionRange(CHROME_MIN, CHROME_MAX)})
+        filterer = Filterer(CHROME_VERSIONS, 'chrome', options)
         self.assertEqual(len(filterer.versions), (CHROME_MAX - CHROME_MIN) + 1)
 
     def test_weighted_versions(self):
-        filterer = Filterer(CHROME_VERSIONS)
-        filterer.weighted_versions()
+        filterer = Filterer(CHROME_VERSIONS, 'chrome', Options(weighted_versions=True))
+        self.assertEqual(len(filterer.versions), 1)
+
+    def test_latest_versions(self):
+        filterer = Filterer(CHROME_VERSIONS, 'chrome', Options(latest_versions={'chrome': 3}))
+        self.assertEqual(filterer.versions, CHROME_VERSIONS[-3:])
+
+    def test_options_filters_versions_on_init(self):
+        options = Options(latest_versions={'chrome': 3})
+        filterer = Filterer(CHROME_VERSIONS, 'chrome', options)
+        self.assertEqual(filterer.versions, CHROME_VERSIONS[-3:])
+
+    def test_options_weighted_versions_is_optional(self):
+        filterer = Filterer(CHROME_VERSIONS, 'chrome', Options(weighted_versions=False))
+        self.assertEqual(len(filterer.versions), len(CHROME_VERSIONS))
+
+        filterer = Filterer(CHROME_VERSIONS, 'chrome', Options(weighted_versions=True), max_weighted_version=3)
         self.assertEqual(len(filterer.versions), 1)
 
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,11 +1,13 @@
 """
 Random User-Agent
-Copyright: 2024 Ekin Karadeniz (github.com/iamdual)
+Copyright: 2024-2026 Ekin Karadeniz (github.com/iamdual)
 License: Apache License 2.0 
 """
 import unittest
 
 import src.ua_generator as ua_generator
+from src.ua_generator.data.browsers.chrome import VERSIONS as CHROME_VERSIONS
+from src.ua_generator.data.platforms.ios import VERSIONS as IOS_VERSIONS
 from src.ua_generator.data.version import VersionRange
 from src.ua_generator.options import Options
 
@@ -14,6 +16,7 @@ class TestOptions(unittest.TestCase):
     def test_weighted_versions(self):
         ua = ua_generator.generate()
         self.assertFalse(ua.options.weighted_versions)
+        self.assertFalse(ua.options.latest_versions)
         ua = ua_generator.generate(options=Options(weighted_versions=True))
         self.assertTrue(ua.options.weighted_versions)
         ua = ua_generator.generate(options=Options(weighted_versions=False))
@@ -29,6 +32,30 @@ class TestOptions(unittest.TestCase):
         for i in range(0, 100):
             ua = ua_generator.generate(browser='chrome', options=options)
             self.assertIn(ua.generator.browser_version.major, (125, 126, 127))
+
+    def test_latest_versions_true(self):
+        options = Options()
+        options.latest_versions = True
+
+        for i in range(0, 100):
+            ua = ua_generator.generate(platform='ios', browser='chrome', options=options)
+            self.assertEqual(ua.generator.browser_version.to_tuple(), CHROME_VERSIONS[-1].to_tuple())
+            self.assertEqual(ua.generator.platform_version.to_tuple(), IOS_VERSIONS[-1].to_tuple())
+
+    def test_latest_versions_dict(self):
+        options = Options()
+        options.latest_versions = {
+            'chrome': 3,
+            'ios': 3,
+        }
+
+        latest_chrome_versions = [version.to_tuple() for version in CHROME_VERSIONS[-3:]]
+        latest_ios_versions = [version.to_tuple() for version in IOS_VERSIONS[-3:]]
+
+        for i in range(0, 100):
+            ua = ua_generator.generate(platform='ios', browser='chrome', options=options)
+            self.assertIn(ua.generator.browser_version.to_tuple(), latest_chrome_versions)
+            self.assertIn(ua.generator.platform_version.to_tuple(), latest_ios_versions)
 
     def test_tied_safari_version(self):
         for i in range(0, 100):


### PR DESCRIPTION
This resolves #54 

The `latest_versions` option is implemented to choose only the latest version, or one of the latest `N` versions for specified browsers or platforms.

```python
import ua_generator
from ua_generator.options import Options

# Choose only the latest version for every browser and platform
options = Options()
options.latest_versions = True
ua = ua_generator.generate(options=options)

# Choose one of the latest N versions for specified browsers and platforms
options = Options()
options.latest_versions = {
    'chrome': 3,
    'firefox': 1,
    'ios': 3,
    'macos': 1,
}
ua = ua_generator.generate(browser='chrome', platform='ios', options=options)
```